### PR TITLE
Adds extra locations of Melemele Island

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <p><b>AMB</b> means ambush encounter, and <b>IS</b> means Island Scan. <b>Ally Pokemon</b> that are different to the original caller are <b>highlighted in orange</b>, and are below the caller.</p>
     <div id="route1">
       <h3><a href="#route1">Route 1</a></h3>
+      <p>Melemele Island</p>
         <h4>Proper</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 30%<br />
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -95,6 +96,7 @@
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
         <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 20%<br />
@@ -111,6 +113,7 @@
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="spearow" /><span class="pkspr pkmn-spearow"></span> Spearow - 40%<br />
         <input type="checkbox" value="mankey" /><span class="pkspr pkmn-mankey"></span> Mankey - 20%<br />
@@ -130,6 +133,7 @@
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -151,6 +155,7 @@
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
+      <p>Akala Island</p>
         <h4>Southern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
           <div class="ally">
@@ -179,6 +184,7 @@
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -201,6 +207,7 @@
     </div>
     <div id="route7">
       <h3><a href="#route7">Route 7</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
@@ -219,6 +226,7 @@
     </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
+      <p>Akala Island</p>
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
           <input type="checkbox" value="fletchinder" /><span class="pkspr pkmn-fletchinder"></span> Fletchinder - 15%<br />
           <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
@@ -244,6 +252,7 @@
     </div>
     <div id="route9">
       <h3><a href="#route9">Route 9</a></h3>
+      <p>Akala Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 15%<br />
           <div class="ally">
@@ -260,6 +269,7 @@
     </div>
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -280,6 +290,7 @@
     </div>
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
           <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -297,6 +308,7 @@
     </div>
     <div id="route12">
       <h3><a href="#route12">Route 12</a></h3>
+      <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
           <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
@@ -315,6 +327,7 @@
     </div>
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
           <div class="ally">
@@ -333,6 +346,7 @@
     </div>
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
@@ -352,6 +366,7 @@
     </div>
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -377,6 +392,7 @@
     </div>
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -387,6 +403,7 @@
     </div>
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
       <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
+      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
@@ -192,6 +193,15 @@
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% (Berry tree)<br />
         <input type="checkbox" value="chikorita" /><span class="pkspr pkmn-chikorita"></span> Chikorita - One (IS)<br />
       <br />
+    </div>
+    <div id="hauoli-cemetery">
+        <h3><a href="#hauoli-cemetery">Hau'oli Cemetery</a></h3>
+        <p>Melemele Island</p>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+          <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+          <input type="checkbox" value="misdreavus" /><span class="pkspr pkmn-misdreavus"></span>Misdreavus - 30% (N)<br />
+          <input type="checkbox" value="drifloon" /><span class="pkspr pkmn-drifloon"></span>Drifloon - 30% (D)<br />
+     <br />
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
+      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+      <li><a href="#seward-cave">Seaward Cave</a></li>
+      <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
       <li><a href="#route6">Route 6</a></li>
@@ -131,27 +134,15 @@
             <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
             <br />
         <h4>Fishing</h4>
-            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%<br />
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%, 20% @ bubble spot<br />
             <div class="ally">
                 <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
             </div>
-            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%<br />
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%, 20% @ bubble spot<br />
             <div class="ally">
                 <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
             </div>
-            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%<br />
-            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
-            <br />
-        <h4>Fishing at a bubbling spot</h4>
-            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 20%<br />
-            <div class="ally">
-                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
-            </div>
-            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 20%<br />
-            <div class="ally">
-                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
-            </div>
-            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 40%<br />
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%, 40% @ bubble spot<br />
             <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
             <br />
     </div>
@@ -222,6 +213,77 @@
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
       <br />
+    </div>
+    <div id="melemele-meadow">
+        <h3><a href="#melemele-meadow">Melemele Meadow</a></h3>
+        <p>Melemele Island</p>
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+            <div class="ally">
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
+            <div class="ally">
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
+            <br />
+    </div>
+    <div id="seaward-cave">
+        <h3><a href="#seward-cave">Seaward Cave</a></h3>
+        <p>Melemele Island</p>
+        <h4>Walking</h4>
+            <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 70%<br />
+            <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 30%<br />
+            <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 99%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 1%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+            </div>
+            <br />
+    </div>
+    <div id="kalae-bay">
+        <h3><a href="#kalae-bay">Kala'e Bay</a></h3>
+        <p>Melemele Island</p>
+        <h4>Grass</h4>
+          <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
+          <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="slowbro" /><span class="pkspr pkmn-slowbro"></span> Slowbro - Ally ^<br />
+          </div>
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 40%<br />
+          <input type="checkbox" value="bagon" /><span class="pkspr pkmn-bagon"></span> Bagon - 10%<br />
+          <div class="ally">
+              <input type="checkbox" value="shelgon" /><span class="pkspr pkmn-shelgon"></span> Shelgon - Ally ^<br />
+          </div>
+          <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+        <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+          <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+          <br />
+        <h4>Fishing</h4>
+          <input type="checkbox" value="shellder" /><span class="pkspr pkmn-shellder"></span> Shellder - 1%, 20% @ bubble spot<br />
+	          <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+	          <div class="ally">
+	            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+	          </div>
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 30% @ bubble spot<br />
+          <br />
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <li><a href="#route1">Route 1</a></li>
       <li><a href="#melemele-sea">Melemele Sea</a></li>
       <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
-      <li><a href="#huoli-city">Hu'oli City</a></li>
+      <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
@@ -155,7 +155,7 @@
             <br />
     </div>
     <div id="huoli-city">
-        <h3><a href="#huoli-city">Hu'Oli City</a></h3>
+        <h3><a href="#hauoli-city">Hau'oli City</a></h3>
         <p>Melemele Island</p>
         <h4>Surfing</h4>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
   <div class="main">
     <ul>
       <li><a href="#route1">Route 1</a></li>
+      <li><a href="#melemele-sea">Melemele Sea</a></li>
+      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+      <li><a href="#huoli-city">Hu'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
@@ -78,27 +81,6 @@
             <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
           </div>
           <br />
-        <h4>Ten Carat Hill</h4>
-        <h5>Cave and ocean Cave</h5>
-          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
-          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
-          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
-          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
-          <div class="ally">
-            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
-          </div>
-          <br />
-        <h5>Surfing</h5>
-          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
-          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
-          <br />
-        <h5>Farthest Hollow</h5>
-          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
-          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
-          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
-          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
-          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
-          <br />
         <h4>Hau'oli Outskirts</h4>
           <h5>Beachfront</h5>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -114,6 +96,85 @@
           <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 50%<br />
           <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 20%<br />
       <br />
+    </div>
+    <div id="ten-carat-hill">
+        <h3><a href="#ten-carat-hill">Ten Carat Hill</a></h3>
+        <p>Melemele Island</p>
+        <h4>Cave and ocean Cave</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Farthest Hollow</h4>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
+    </div>
+    <div id="melemele-sea">
+        <h3><a href="#melemele-sea"> Melemele Sea</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+        <h4>Fishing at a bubbling spot</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 20%<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 20%<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 40%<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+    </div>
+    <div id="huoli-city">
+        <h3><a href="#huoli-city">Hu'Oli City</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+        <h4>Shopping District</h4>
+            <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
+            <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
+            <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 25%<br />
+            <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 10%<br />
+            <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 10%<br />
+            <input type="checkbox" value="pichu" /><span class="pkspr pkmn-pichu"></span> Pichu - 5%<br />
+            <div class="ally">
+                <input type="checkbox" value="pikachu" /><span class="pkspr pkmn-pikachu"></span> Pikachu - Ally ^<br />
+                <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+            </div>
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 20% (D)<br />
+        <br />
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
@@ -285,7 +346,6 @@
           </div>
           <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 70%<br />
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
-
       <br />
     </div>
     <div id="route10">
@@ -331,7 +391,7 @@
       <h3><a href="#route12">Route 12</a></h3>
       <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
-          <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
           <div class="ally">
             <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
@@ -454,7 +514,7 @@
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
     PkSpr.process_dom();
@@ -482,7 +542,7 @@
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
   <br />
-<p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</p>.
+  <p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -78,6 +78,27 @@
             <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
           </div>
           <br />
+        <h4>Ten Carat Hill</h4>
+        <h5>Cave and ocean Cave</h5>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h5>Surfing</h5>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h5>Farthest Hollow</h5>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
         <h4>Hau'oli Outskirts</h4>
           <h5>Beachfront</h5>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />

--- a/night.html
+++ b/night.html
@@ -52,6 +52,7 @@
     <p><b>AMB</b> means ambush encounter, and <b>IS</b> means Island Scan. <b>Ally Pokemon</b> that are different to the original caller are highlighted in orange, and are below the caller.</p>
     <div id="route1">
       <h3><a href="#route1">Route 1</a></h3>
+      <p>Melemele Island</p>
         <h4>Proper</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 30%<br />
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -95,6 +96,7 @@
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
         <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 20%<br />
@@ -111,6 +113,7 @@
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="spearow" /><span class="pkspr pkmn-spearow"></span> Spearow - 40%<br />
         <input type="checkbox" value="mankey" /><span class="pkspr pkmn-mankey"></span> Mankey - 20%<br />
@@ -130,6 +133,7 @@
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -151,6 +155,7 @@
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
+      <p>Akala Island</p>
         <h4>Southern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
           <div class="ally">
@@ -179,6 +184,7 @@
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -201,6 +207,7 @@
     </div>
     <div id="route7">
       <h3><a href="#route7">Route 7</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
@@ -219,6 +226,7 @@
     </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
+      <p>Akala Island</p>
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
           <input type="checkbox" value="fletchinder" /><span class="pkspr pkmn-fletchinder"></span> Fletchinder - 15%<br />
           <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
@@ -244,6 +252,7 @@
     </div>
     <div id="route9">
       <h3><a href="#route9">Route 9</a></h3>
+      <p>Akala Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 15%<br />
           <div class="ally">
@@ -260,6 +269,7 @@
     </div>
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -280,6 +290,7 @@
     </div>
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
           <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -297,6 +308,7 @@
     </div>
     <div id="route12">
       <h3><a href="#route12">Route 12</a></h3>
+      <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
           <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
@@ -315,6 +327,7 @@
     </div>
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
           <div class="ally">
@@ -333,6 +346,7 @@
     </div>
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
@@ -352,6 +366,7 @@
     </div>
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -377,6 +392,7 @@
     </div>
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -387,6 +403,7 @@
     </div>
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />

--- a/night.html
+++ b/night.html
@@ -23,10 +23,18 @@
   <!-- end -->
 </head>
 <body>
+  <div class="main">
     <ul>
       <li><a href="#route1">Route 1</a></li>
+      <li><a href="#melemele-sea">Melemele Sea</a></li>
+      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+      <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
+      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
+      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+      <li><a href="#seward-cave">Seaward Cave</a></li>
+      <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
       <li><a href="#route6">Route 6</a></li>
@@ -94,6 +102,73 @@
           <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 20%<br />
       <br />
     </div>
+    <div id="ten-carat-hill">
+        <h3><a href="#ten-carat-hill">Ten Carat Hill</a></h3>
+        <p>Melemele Island</p>
+        <h4>Cave and ocean Cave</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Farthest Hollow</h4>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
+    </div>
+    <div id="melemele-sea">
+        <h3><a href="#melemele-sea"> Melemele Sea</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%, 20% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%, 20% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%, 40% @ bubble spot<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+    </div>
+    <div id="huoli-city">
+        <h3><a href="#hauoli-city">Hau'oli City</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+        <h4>Shopping District</h4>
+            <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
+            <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
+            <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 25%<br />
+            <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 10%<br />
+            <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 10%<br />
+            <input type="checkbox" value="pichu" /><span class="pkspr pkmn-pichu"></span> Pichu - 5%<br />
+            <div class="ally">
+                <input type="checkbox" value="pikachu" /><span class="pkspr pkmn-pikachu"></span> Pikachu - Ally ^<br />
+                <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+            </div>
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 20% (D)<br />
+        <br />
+    </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
       <p>Melemele Island</p>
@@ -110,6 +185,15 @@
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% (Berry tree)<br />
         <input type="checkbox" value="chikorita" /><span class="pkspr pkmn-chikorita"></span> Chikorita - One (IS)<br />
       <br />
+    </div>
+    <div id="hauoli-cemetery">
+        <h3><a href="#hauoli-cemetery">Hau'oli Cemetery</a></h3>
+        <p>Melemele Island</p>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+          <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+          <input type="checkbox" value="misdreavus" /><span class="pkspr pkmn-misdreavus"></span>Misdreavus - 30% (N)<br />
+          <input type="checkbox" value="drifloon" /><span class="pkspr pkmn-drifloon"></span>Drifloon - 30% (D)<br />
+     <br />
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
@@ -130,6 +214,77 @@
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
       <br />
+    </div>
+    <div id="melemele-meadow">
+        <h3><a href="#melemele-meadow">Melemele Meadow</a></h3>
+        <p>Melemele Island</p>
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+            <div class="ally">
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
+            <div class="ally">
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
+            <br />
+    </div>
+    <div id="seaward-cave">
+        <h3><a href="#seward-cave">Seaward Cave</a></h3>
+        <p>Melemele Island</p>
+        <h4>Walking</h4>
+            <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 70%<br />
+            <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 30%<br />
+            <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 99%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 1%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+            </div>
+            <br />
+    </div>
+    <div id="kalae-bay">
+        <h3><a href="#kalae-bay">Kala'e Bay</a></h3>
+        <p>Melemele Island</p>
+        <h4>Grass</h4>
+          <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
+          <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="slowbro" /><span class="pkspr pkmn-slowbro"></span> Slowbro - Ally ^<br />
+          </div>
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 40%<br />
+          <input type="checkbox" value="bagon" /><span class="pkspr pkmn-bagon"></span> Bagon - 10%<br />
+          <div class="ally">
+              <input type="checkbox" value="shelgon" /><span class="pkspr pkmn-shelgon"></span> Shelgon - Ally ^<br />
+          </div>
+          <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+        <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+          <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+          <br />
+        <h4>Fishing</h4>
+          <input type="checkbox" value="shellder" /><span class="pkspr pkmn-shellder"></span> Shellder - 1%, 20% @ bubble spot<br />
+	          <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+	          <div class="ally">
+	            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+	          </div>
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 30% @ bubble spot<br />
+          <br />
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
@@ -264,7 +419,6 @@
           </div>
           <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 70%<br />
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
-
       <br />
     </div>
     <div id="route10">
@@ -310,7 +464,7 @@
       <h3><a href="#route12">Route 12</a></h3>
       <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
-          <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
           <div class="ally">
             <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
@@ -433,7 +587,7 @@
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
     PkSpr.process_dom();
@@ -457,7 +611,7 @@
 </script>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   <script type="text/javascript">
     PkSpr.process_dom();
   </script>
@@ -467,7 +621,7 @@
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
   <br />
-<p class="padding">By <a href="giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="github.com/giacomolaw/pokefinder" target="_blank">Pokefinder contributors</p>.
+  <p class="padding">By <a href="giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="github.com/giacomolaw/pokefinder" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>


### PR DESCRIPTION
This PR adds information about other locations aside from the route on the Melemele Island.

This information is useful to help complete the Melemele Pokedex, as some pokemons are found exclusively on some of this locations.

I'll be adding more information of the other islands as follow up pull requests.

Relates to issue #13 