### PR TITLE
Adds missing information of named locations

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,7 @@ ul li {
     display: inline-table;
     width: 20%;
     text-align: center;
-    font-size: 1.5vmin;
+    height: 3em;
 }
 
 li a {
@@ -67,7 +67,6 @@ li a {
 @media only screen and (max-width: 500px) {
     ul li {
         width: 33%;
-        font-size: 0.6em;
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -29,7 +29,7 @@ button:hover {
 .center {
     margin-left: auto;
     margin-right: auto;
-    width: 400px;
+    width: 90%;
 }
 
 .ally {
@@ -53,7 +53,7 @@ ul li {
     display: inline-table;
     width: 20%;
     text-align: center;
-    font-size: 1vmin;
+    font-size: 1.5vmin;
 }
 
 li a {
@@ -67,6 +67,7 @@ li a {
 @media only screen and (max-width: 500px) {
     ul li {
         width: 33%;
+        font-size: 0.6em;
     }
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -45,10 +45,15 @@ ul {
     margin: 0;
     padding: 0;
     background-color: #f1f1f1;
+    width: 100%;
+    display: table;
 }
 
 ul li {
-    display: inline-block;
+    display: inline-table;
+    width: 20%;
+    text-align: center;
+    font-size: 1vmin;
 }
 
 li a {
@@ -57,6 +62,20 @@ li a {
      padding: 6px 14px;
      text-decoration: none;
 }
+
+/* Make the menu responsive depending of the screen width */
+@media only screen and (max-width: 500px) {
+    ul li {
+        width: 33%;
+    }
+}
+
+@media only screen and (min-width: 1024px) {
+    ul li {
+        width: 10%;
+    }
+}
+
 
 /* Change the link color on hover */
 li a:hover {
@@ -136,4 +155,24 @@ input#lightswitch:checked + footer {
 
 input#lightswitch:checked + a {
    color: #008B8B;
+}
+
+/* Organizing the content to better fill the screen */
+@media only screen and (min-width: 1024px) {
+    .center {
+        width: 100%;
+        padding: 2em 5em;
+        flex-wrap: wrap;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-evenly;
+    }
+    .center > div {
+        padding: 2.5em 0.5em;
+        width: 33%;
+    }
+
+    .center > div h3, .center > div h3 + p {
+        text-align: center;
+    }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -49,11 +49,31 @@ ul {
     display: table;
 }
 
-ul li {
-    display: inline-table;
-    width: 20%;
+nav > ul {
+    flex-wrap: wrap;
+    display: flex;
+    flex-direction: row;
+}
+
+nav > ul > li {
+    width: 25%;
+    display: table-cell;
     text-align: center;
-    height: 3em;
+    padding: 1em 0;
+}
+
+@media only screen and (max-width: 512px) {
+    nav > ul > li {
+        width: 100%;
+    }
+}
+
+nav ul ul {
+    display: none;
+}
+
+nav li:target ul {
+    display: inline;
 }
 
 li a {
@@ -63,17 +83,8 @@ li a {
      text-decoration: none;
 }
 
-/* Make the menu responsive depending of the screen width */
-@media only screen and (max-width: 500px) {
-    ul li {
-        width: 33%;
-    }
-}
-
-@media only screen and (min-width: 1024px) {
-    ul li {
-        width: 10%;
-    }
+nav > ul > li > a {
+    font-weight: bold;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="css/pokesprite.min.css" type="text/css" />
   <link rel="stylesheet" href="css/bootstrap.css" type="text/css" />
-  <link rel="stylesheet" href="css/style.css?cachebust" type="text/css" />
+  <link rel="stylesheet" href="css/style.css" type="text/css" />
   <script src="js/pokesprite.min.js" type="text/javascript"></script>
   <link rel="shortcut icon" href="img/favicon.ico" />
   <!-- Google analytics -->

--- a/index.html
+++ b/index.html
@@ -52,6 +52,7 @@
     <p><b>AMB</b> means ambush encounter, and <b>IS</b> means Island Scan. <b>Ally Pokemon</b> that are different to the original caller are <b>highlighted in orange</b>, and are below the caller.</p>
     <div id="route1">
       <h3><a href="#route1">Route 1</a></h3>
+      <p>Melemele Island</p>
         <h4>Proper</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 30%<br />
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -95,6 +96,7 @@
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
         <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 20%<br />
@@ -111,6 +113,7 @@
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="spearow" /><span class="pkspr pkmn-spearow"></span> Spearow - 40%<br />
         <input type="checkbox" value="mankey" /><span class="pkspr pkmn-mankey"></span> Mankey - 20%<br />
@@ -130,6 +133,7 @@
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -151,6 +155,7 @@
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
+      <p>Akala Island</p>
         <h4>Southern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
           <div class="ally">
@@ -179,6 +184,7 @@
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -201,6 +207,7 @@
     </div>
     <div id="route7">
       <h3><a href="#route7">Route 7</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
@@ -219,6 +226,7 @@
     </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
+      <p>Akala Island</p>
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
           <input type="checkbox" value="fletchinder" /><span class="pkspr pkmn-fletchinder"></span> Fletchinder - 15%<br />
           <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
@@ -244,6 +252,7 @@
     </div>
     <div id="route9">
       <h3><a href="#route9">Route 9</a></h3>
+      <p>Akala Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 15%<br />
           <div class="ally">
@@ -260,6 +269,7 @@
     </div>
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -280,6 +290,7 @@
     </div>
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
           <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -297,6 +308,7 @@
     </div>
     <div id="route12">
       <h3><a href="#route12">Route 12</a></h3>
+      <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
           <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
@@ -315,6 +327,7 @@
     </div>
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
           <div class="ally">
@@ -333,6 +346,7 @@
     </div>
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
@@ -352,6 +366,7 @@
     </div>
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -377,6 +392,7 @@
     </div>
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -387,6 +403,7 @@
     </div>
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
       <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
+      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
@@ -192,6 +193,15 @@
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% (Berry tree)<br />
         <input type="checkbox" value="chikorita" /><span class="pkspr pkmn-chikorita"></span> Chikorita - One (IS)<br />
       <br />
+    </div>
+    <div id="hauoli-cemetery">
+        <h3><a href="#hauoli-cemetery">Hau'oli Cemetery</a></h3>
+        <p>Melemele Island</p>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+          <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+          <input type="checkbox" value="misdreavus" /><span class="pkspr pkmn-misdreavus"></span>Misdreavus - 30% (N)<br />
+          <input type="checkbox" value="drifloon" /><span class="pkspr pkmn-drifloon"></span>Drifloon - 30% (D)<br />
+     <br />
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>

--- a/index.html
+++ b/index.html
@@ -55,10 +55,15 @@
       <li><a href="#route12">Route 12</a></li>
       <li><a href="#blush-mountain">Blush Mountain</a></li>
       <li><a href="#route13">Route 13</a></li>
+      <li><a href="#haina-desert">Haina Desert</a></li>
+      <li><a href="#tapu-village">Tapu Village</a></li>
       <li><a href="#route14">Route 14</a></li>
+      <li><a href="#abandoned-site">Abandoned Site</a></li>
       <li><a href="#route15">Route 15</a></li>
       <li><a href="#route16">Route 16</a></li>
+      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
       <li><a href="#route17">Route 17</a></li>
+      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
     </ul>
   <div class="center padding">
     <br>
@@ -770,7 +775,7 @@
           <input type="checkbox" value="torkoal" /><span class="pkspr pkmn-torkoal"></span> Torkoal - 10% or 20%<br />
           <input type="checkbox" value="charjabug" /><span class="pkspr pkmn-charjabug"></span> Charjabug - 10%<br />
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 20%<br />
-          <input type="checkbox" value="turtonator" /><span class="pkspr pkmn-turtonator"></span> Turtonator - 10%<br />
+          <input type="checkbox" value="turtonator" /><span class="pkspr pkmn-turtonator"></span> Turtonator - 10% (Sun)<br />
           <input type="checkbox" value="togedemaru" /><span class="pkspr pkmn-togedemaru"></span> Togedemaru - 10%<br />
       <br />
     </div>
@@ -795,12 +800,51 @@
       <br />
     </div>
 
+    <div id="haina-desert">
+        <h3><a href="#haina-desert">Haina Desert</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="dugtrio" /><span class="pkspr pkmn-dugtrio form-alola"></span> Dugtrio - 30%, 20% @ Ambush<br />
+        <input type="checkbox" value="sandile" /><span class="pkspr pkmn-sandile form-alola"></span> Sandile - 70% <br />
+        <input type="checkbox" value="trapinch" /><span class="pkspr pkmn-trapinch form-alola"></span> Trapinch - 10% @ Ambush<br />
+        <br />
+
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="gabite" /><span class="pkspr pkmn-gabite"></span> Gabite - Sandstorm - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Sandstorm - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Hail ~10%<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="tapu-village">
+        <p>Ula'ula Island</p>
+        <h3><a href="#tapu-village">Tapu Village</a></h3>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="sandshrew" /><span class="pkspr pkmn-sandshrew form-alola"></span> Sandshrew - 10% (Moon)<br />
+        <input type="checkbox" value="vulpix" /><span class="pkspr pkmn-vulpix form-alola"></span> Vulpix - 10% (Sun)<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 10%<br />
+        <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 20%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="vanillite" /><span class="pkspr pkmn-vanillite"></span> Vanillite - In hail - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Sandstorm ~10%<br />
+        </div>
+        <br />
+    </div>
+
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
       <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
-          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
+          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br /><br />
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
@@ -815,6 +859,20 @@
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
       <br />
     </div>
+
+    <div id="abandoned-site">
+        <h3><a href="#abandoned-site">Abandoned Site</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 40%<br />
+        <input type="checkbox" value="haunter" /><span class="pkspr pkmn-haunter"></span>Haunter - 40%<br />
+        <div class="ally">
+            <input type="checkbox" value="gengar" /><span class="pkspr pkmn-gengar"></span>Gengar - Ally ^<br />
+        </div>
+        <input type="checkbox" value="klefki" /><span class="pkspr pkmn-klefki"></span>Klefki - 15%<br />
+        <input type="checkbox" value="mimikyu" /><span class="pkspr pkmn-mimikyu"></span>Mimikyu - 5%<br />
+        <br />
+    </div>
+
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
       <p>Ula'ula Island</p>
@@ -824,7 +882,7 @@
           <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
-          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
+          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br /><br />
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
@@ -838,9 +896,11 @@
           <div class="ally">
             <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
           </div>
-          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 30%<br /><br />
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 30%<br />
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
+          <br />
     </div>
+
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
       <p>Ula'ula Island</p>
@@ -852,6 +912,19 @@
           <input type="checkbox" value="duosion" /><span class="pkspr pkmn-duosion"></span> Duosion - One (IS)<br />
       <br />
     </div>
+
+    <div id="ulaula-meadow">
+        <h3><a href="#ulaula-meadow">Ula'ula Meadow</a></h3>
+        <p>Ula'ula Island</p>
+          <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
+          <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+        <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
+        <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
+        <br />
+    </div>
+
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
       <p>Ula'ula Island</p>
@@ -879,6 +952,40 @@
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - ~10%<br />
           </div>
+      <br />
+    </div>
+
+    <div id="mount-lanakila">
+      <h3><a href="#mount-lanakila">Mount Lanakila</a></h3>
+
+      <h4>Grass</h4>
+      <input type="checkbox" value="sandshrew" /><span class="pkspr pkmn-sandshrew form-alola"></span> Sandshrew - 30% (Moon)<br />
+      <input type="checkbox" value="vulpix" /><span class="pkspr pkmn-vulpix form-alola"></span> Vulpix - 30% (Sun)<br />
+      <input type="checkbox" value="sneasel" /><span class="pkspr pkmn-sneasel"></span> Sneasel - 20%<br />
+      <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 20%<br />
+      <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 30%<br />
+      <div class="ally">
+          <input type="checkbox" value="glalie" /><span class="pkspr pkmn-glalie"></span> Glalie - Ally ^<br />
+      </div>
+      <br />
+      <div class="ally">
+          <h5>Special allies in weather</h5>
+          <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+          <input type="checkbox" value="vanillish" /><span class="pkspr pkmn-vanillish"></span> Vanillish - In hail - ~10%<br />
+          <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail - ~1%<br />
+          <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Sandstorm ~10%<br />
+      </div>
+      <br />
+
+      <h4>Cave</h4>
+      <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 30%<br />
+      <input type="checkbox" value="sneasel" /><span class="pkspr pkmn-sneasel"></span> Sneasel - 20%<br />
+      <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 10% or 20%<br />
+      <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 30%<br />
+      <div class="ally">
+          <input type="checkbox" value="glalie" /><span class="pkspr pkmn-glalie"></span> Glalie - Ally ^<br />
+      </div>
+      <input type="checkbox" value="drampa" /><span class="pkspr pkmn-drampa"></span> Drampa - 10% (Moon)<br />
       <br />
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
+      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+      <li><a href="#seward-cave">Seaward Cave</a></li>
+      <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
       <li><a href="#route6">Route 6</a></li>
@@ -131,27 +134,15 @@
             <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
             <br />
         <h4>Fishing</h4>
-            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%<br />
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%, 20% @ bubble spot<br />
             <div class="ally">
                 <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
             </div>
-            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%<br />
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%, 20% @ bubble spot<br />
             <div class="ally">
                 <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
             </div>
-            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%<br />
-            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
-            <br />
-        <h4>Fishing at a bubbling spot</h4>
-            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 20%<br />
-            <div class="ally">
-                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
-            </div>
-            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 20%<br />
-            <div class="ally">
-                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
-            </div>
-            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 40%<br />
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%, 40% @ bubble spot<br />
             <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
             <br />
     </div>
@@ -222,6 +213,77 @@
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
       <br />
+    </div>
+    <div id="melemele-meadow">
+        <h3><a href="#melemele-meadow">Melemele Meadow</a></h3>
+        <p>Melemele Island</p>
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+            <div class="ally">
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
+            <div class="ally">
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
+            <br />
+    </div>
+    <div id="seaward-cave">
+        <h3><a href="#seward-cave">Seaward Cave</a></h3>
+        <p>Melemele Island</p>
+        <h4>Walking</h4>
+            <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 70%<br />
+            <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 30%<br />
+            <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 99%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 1%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+            </div>
+            <br />
+    </div>
+    <div id="kalae-bay">
+        <h3><a href="#kalae-bay">Kala'e Bay</a></h3>
+        <p>Melemele Island</p>
+        <h4>Grass</h4>
+          <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
+          <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="slowbro" /><span class="pkspr pkmn-slowbro"></span> Slowbro - Ally ^<br />
+          </div>
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 40%<br />
+          <input type="checkbox" value="bagon" /><span class="pkspr pkmn-bagon"></span> Bagon - 10%<br />
+          <div class="ally">
+              <input type="checkbox" value="shelgon" /><span class="pkspr pkmn-shelgon"></span> Shelgon - Ally ^<br />
+          </div>
+          <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+        <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+          <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+          <br />
+        <h4>Fishing</h4>
+          <input type="checkbox" value="shellder" /><span class="pkspr pkmn-shellder"></span> Shellder - 1%, 20% @ bubble spot<br />
+	          <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+	          <div class="ally">
+	            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+	          </div>
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 30% @ bubble spot<br />
+          <br />
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,15 @@
       <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
       <li><a href="#route17">Route 17</a></li>
       <li><a href="#mount-lanakila">Mount Lanakila</a></li>
+      <li><a href="#seafolk-village">Seafolk Village</a></li>
+      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
+      <li><a href="#poni-wilds">Poni Wilds</a></li>
+      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
+      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
+      <li><a href="#poni-grove">Poni Grove</a></li>
+      <li><a href="#poni-plains">Poni Plains</a></li>
+      <li><a href="#poni-meadow">Poni Meadow</a></li>
+      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
     </ul>
   <div class="center padding">
     <br>
@@ -106,11 +115,13 @@
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
             <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 50%<br />
-            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br /><br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+            <br />
           <h6>Surfing</h6>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
-            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
         <h4>Trainers' School</h4>
           <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
           <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 50%<br />
@@ -168,7 +179,8 @@
         <h4>Surfing</h4>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
-            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
         <h4>Shopping District</h4>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
             <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
@@ -224,7 +236,8 @@
             <input type="checkbox" value="salamence" /><span class="pkspr pkmn-salamence"></span> Salamence - Ally ^<br />
           </div>
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabwraler - 100% (Berry tree)<br />
-        <input type="checkbox" value="cyndaquil" /><span class="pkspr pkmn-cyndaquil"></span> Cyndaquil - One (IS)<br /><br />
+        <input type="checkbox" value="cyndaquil" /><span class="pkspr pkmn-cyndaquil"></span> Cyndaquil - One (IS)<br />
+        <br />
         <h5>Ambush encounters</h5>
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
@@ -243,8 +256,8 @@
                 <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
             </div>
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
-            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
-            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30% (Sun)<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30% (Moon)<br />
             <input type="checkbox" value="oricorio-pom-pom" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
             <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
             <br />
@@ -327,16 +340,16 @@
       <h3><a href="#paniola-ranch">Paniola Ranch</a></h3>
       <p>Akala Island</p>
         <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 5%<br />
-          <div class="ally">
+        <div class="ally">
             <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
-          </div>
-          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
-          <div class="ally">
-              <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
-          </div>
-          <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
-          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
-          <br />
+        </div>
+        <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
+        <div class="ally">
+            <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+        </div>
+        <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
+        <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
+        <br />
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
@@ -354,7 +367,8 @@
           <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 30%<br />
           <input type="checkbox" value="pikipek" /><span class="pkspr pkmn-pikipek"></span> pikipek - 20%<br />
           <input type="checkbox" value="grubbin" /><span class="pkspr pkmn-grubbin"></span> Grubbin - 10%<br />
-          <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br /><br />
+          <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br />
+          <br />
         <h4>Northern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 15%<br />
           <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 10%<br />
@@ -551,7 +565,7 @@
           <input type="checkbox" value="salandit" /><span class="pkspr pkmn-salandit"></span> Salandit - 20%<br />
           <input type="checkbox" value="stufful" /><span class="pkspr pkmn-stufful"></span> Stufful - 20%<br />
           <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% @ Berry Tree<br />
-          <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (AMB)<br /><br />
+          <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (AMB)<br />
           <input type="checkbox" value="luxio" /><span class="pkspr pkmn-luxio"></span> Luxio - One (IS)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
@@ -641,7 +655,7 @@
         <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
         <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 20%<br />
         <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 30%<br />
-        <input type="checkbox" value="trubish" /><span class="pkspr pkmn-trubish"></span> Trubish - 30%<br />
+        <input type="checkbox" value="trubbish" /><span class="pkspr pkmn-trubbish"></span> Trubbish - 30%<br />
         <div class="ally">
             <input type="checkbox" value="garbodor" /><span class="pkspr pkmn-garbodor"></span> Garbodor - Ally ^<br />
         </div>
@@ -661,8 +675,8 @@
         <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
         <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
         <input type="checkbox" value="masquerain" /><span class="pkspr pkmn-masquerain"></span> Masquerain - 20% (N)<br />
-        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10%<br />
-        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10%<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10% (Moon)<br />
         <input type="checkbox" value="araquanid" /><span class="pkspr pkmn-araquanid"></span> Araquanid - 20%<br />
         <br />
         <div class="ally">
@@ -918,8 +932,8 @@
         <p>Ula'ula Island</p>
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
           <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
-        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
-        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30% (Moon)<br />
         <input type="checkbox" value="oricorio-baile" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
         <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
         <br />
@@ -988,38 +1002,350 @@
       <input type="checkbox" value="drampa" /><span class="pkspr pkmn-drampa"></span> Drampa - 10% (Moon)<br />
       <br />
     </div>
+
+    <div id="seafolk-village">
+        <h3><a href="#seafolk-village">Seafolk Village</a></h3>
+        <p>Poni Island</p>
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dhelmise" /><span class="pkspr pkmn-dhelmise"></span> Dhelmise - 1%, 10% @ bubble spot<br />
+        <br />
+    </div>
+
+    <div id="exeggutor-island">
+        <h3><a href="#exeggutor-island">Exeggutor Island</a></h3>
+        <p>Poni Island</p>
+        <input type="checkbox" value="exeggcute" /><span class="pkspr pkmn-exeggcute"></span> Exeggcute - 40%<br />
+        <input type="checkbox" value="exeggutor" /><span class="pkspr pkmn-exeggutor form-alola"></span> Exeggutor - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 10%<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="sliggoo" /><span class="pkspr pkmn-sliggoo"></span> Sliggoo - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-wilds">
+        <h3><a href="#poni-wilds">Poni Wilds</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="exeggcute" /><span class="pkspr pkmn-exeggcute"></span> Exeggcute - 10%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 10%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (Ambush - chase)<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="tentacruel" /><span class="pkspr pkmn-tentacruel"></span> Tentacruel - 10% or 20%<br />
+        <div class="ally">
+            <input type="checkbox" value="lumineon" /><span class="pkspr pkmn-lumineon"></span> Lumineon - Ally ^<br />
+        </div>
+        <input type="checkbox" value="lapras" /><span class="pkspr pkmn-lapras"></span> Lapras - 5%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 20%<br />
+        <input type="checkbox" value="lumineon" /><span class="pkspr pkmn-lumineon"></span> Lumineon - 25%<br />
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 90% (Ambush - water splash) <br />
+        <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - 10% (Ambush - water splash) <br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <input type="checkbox" value="relicanth" /><span class="pkspr pkmn-relicanth"></span> Relicanth - 1%, 10% @ bubble spot<br />
+        <br />
+    </div>
+
+    <div id="vast-poni-canyon">
+        <h3><a href="#vast-poni-canyon">Vast Poni Canyon</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Outside</h4>
+        <input type="checkbox" value="machoke" /><span class="pkspr pkmn-machoke"></span> Machoke - 30%<br />
+        <input type="checkbox" value="murkrow" /><span class="pkspr pkmn-murkrow"></span> Murkrow - 10%<br />
+        <input type="checkbox" value="skarmory" /><span class="pkspr pkmn-skarmory"></span> Skarmory - 10%<br />
+        <input type="checkbox" value="boldore" /><span class="pkspr pkmn-boldore"></span> Boldore - 10%<br />
+        <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 15%<br />
+        <input type="checkbox" value="lycanroc-day" /><span class="pkspr pkmn-lycanroc form-midday"></span> Lycanroc (Midday form) - 20% (D)<br />
+        <input type="checkbox" value="lycanroc-night" /><span class="pkspr pkmn-lycanroc form-midnight"></span> Lycanroc (Midnight form) - 20% (N)<br />
+        <input type="checkbox" value="jangmo-o" /><span class="pkspr pkmn-jangmo-o"></span> Jangmo-o - 5%<br />
+        <div class="ally">
+            <input type="checkbox" value="kommo-o" /><span class="pkspr pkmn-kommo-o"></span> Kommo-o - Ally ^<br />
+            <input type="checkbox" value="hakamo-o" /><span class="pkspr pkmn-hakamo-o"></span> Hakamo-o - Ally ^^<br />
+        </div>
+        <br />
+
+        <h4>Caves</h4>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 30%<br />
+        <input type="checkbox" value="dugtrio" /><span class="pkspr pkmn-dugtrio form-alola"></span> Dugtrio - 30%, 100% @ Ambush<br />
+        <input type="checkbox" value="boldore" /><span class="pkspr pkmn-boldore"></span> Boldore - 30%<br />
+        <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 80%<br />
+        <input type="checkbox" value="golduck" /><span class="pkspr pkmn-golduck"></span> Golduck - 20%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-breaker">
+        <h3><a href="#poni-breaker">Poni Breaker Coast</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Ambush Encounters</h4>
+        <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (Ambush - chase)<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="sharpedo" /><span class="pkspr pkmn-sharpedo"></span> Sharpedo - 1%, 10% @ bubble spot<br />
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-grove">
+        <h3><a href="#poni-grove">Poni Grove</a></h3>
+        <p>Poni Island</p>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="pinsir" /><span class="pkspr pkmn-pinsir"></span> Pinsir - 10%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="riolu" /><span class="pkspr pkmn-riolu"></span> Riolu - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="lucario" /><span class="pkspr pkmn-lucario"></span> Lucario - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <br />
+    </div>
+
+    <div id="poni-plains">
+      <h3><a href="#poni-plains">Poni Plains</a></h3>
+      <p>Poni Island</p>
+
+      <h4>7 small fields of grass scattered in the middle</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>2 large fields in the north and around central tree</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="hypno" /><span class="pkspr pkmn-hypno"></span> Hypno - 20%<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>2 fields of grass by the mountain</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 10% (N)<br />
+      <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 20%<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 10% (D)<br />
+      <input type="checkbox" value="mudsdale" /><span class="pkspr pkmn-mudsdale"></span> Mudsdale - 20%<br />
+      <br />
+
+      <h4>3 fields of grass by the coastline</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Grass</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 70% (N)<br />
+      <input type="checkbox" value="hariyama" /><span class="pkspr pkmn-hariyama"></span> Hariyama - 30%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 70% (D)<br />
+      <br />
+
+      <h4>Ambush Encounters - Shadow of Flying Pokemon</h4>
+      <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 70%<br />
+      <input type="checkbox" value="braviary" /><span class="pkspr pkmn-braviary"></span> Braviary - 30% (Sun)<br />
+      <input type="checkbox" value="mandibuzz" /><span class="pkspr pkmn-mandibuzz"></span> Mandibuzz - 30% (Moon)<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Tree</h4>
+      <input type="checkbox" value="primeape" /><span class="pkspr pkmn-primeape"></span> Primeape - 80%<br />
+      <input type="checkbox" value="emolga" /><span class="pkspr pkmn-emolga"></span> Emolga - 20%<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Bushes</h4>
+      <input type="checkbox" value="scyther" /><span class="pkspr pkmn-scyther"></span> Scyther - 30%<br />
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 70% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 70% (Moon)<br />
+      <br />
+
+    </div>
+
+    <div id="poni-meadow">
+        <h3><a href="#poni-meadow">Poni Meadow</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 50% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 50% (Moon)<br />
+        <input type="checkbox" value="oricorio-sensu" /><span class="pkspr pkmn-oricorio form-sensu"></span> Oricorio (Sensu style) - 20%<br />
+        <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-gauntlet">
+        <h3><a href="#poni-gauntlet">Poni Gauntlet</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="golduck" /><span class="pkspr pkmn-golduck"></span> Golduck - 15%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="bewear" /><span class="pkspr pkmn-bewear"></span> Bewear - 5%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
   <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
-    PkSpr.process_dom();
+   PkSpr.process_dom();
   </script>
   <script>
-(function() {
-    var boxes = document.querySelectorAll("input[type='checkbox']");
-    for (var i = 0; i < boxes.length; i++) {
-        var box = boxes[i];
-        setupBox(box);
-    }
-    function setupBox(box) {
-        var storageId = "checkbox" + box.value;
-        var oldVal    = localStorage.getItem(storageId);
-        box.checked = oldVal === "true" ? true : false;
-        box.addEventListener("change", function() {
-            localStorage.setItem(storageId, this.checked);
-        });
-    }
-})();
-</script>
+   (function() {
+       var boxes = document.querySelectorAll("input[type='checkbox']");
+       for (var i = 0; i < boxes.length; i++) {
+           var box = boxes[i];
+           setupBox(box);
+       }
+       function setupBox(box) {
+           var storageId = "checkbox" + box.value;
+           var oldVal    = localStorage.getItem(storageId);
+           box.checked = oldVal === "true" ? true : false;
+           box.addEventListener("change", function() {
+               localStorage.setItem(storageId, this.checked);
+           });
+       }
+   })();
+  </script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   <script src="js/save.js" type="text/javascript"></script>
   <script src="js/checkbox.js" type="text/javascript"></script>
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
-  <br />
-  <p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</a></p>.
+      <br />
+      <p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <li><a href="#route1">Route 1</a></li>
       <li><a href="#melemele-sea">Melemele Sea</a></li>
       <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
-      <li><a href="#huoli-city">Hu'oli City</a></li>
+      <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
@@ -155,7 +155,7 @@
             <br />
     </div>
     <div id="huoli-city">
-        <h3><a href="#huoli-city">Hu'Oli City</a></h3>
+        <h3><a href="#hauoli-city">Hau'oli City</a></h3>
         <p>Melemele Island</p>
         <h4>Surfing</h4>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="css/pokesprite.min.css" type="text/css" />
   <link rel="stylesheet" href="css/bootstrap.css" type="text/css" />
-  <link rel="stylesheet" href="css/style.css" type="text/css" />
+  <link rel="stylesheet" href="css/style.css?cachebust" type="text/css" />
   <script src="js/pokesprite.min.js" type="text/javascript"></script>
   <link rel="shortcut icon" href="img/favicon.ico" />
   <!-- Google analytics -->

--- a/index.html
+++ b/index.html
@@ -47,9 +47,13 @@
       <li><a href="#memorial-hill">Memorial Hill</a></li>
       <li><a href="#akala-outskirts">Akala Outskirts</a></li>
       <li><a href="#hano-beach">Hano Beach</a></li>
+      <li><a href="#malie-city">Malie City</a></li>
+      <li><a href="#malie-garden">Malie Garden</a></li>
       <li><a href="#route10">Route 10</a></li>
+      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
       <li><a href="#route11">Route 11</a></li>
       <li><a href="#route12">Route 12</a></li>
+      <li><a href="#blush-mountain">Blush Mountain</a></li>
       <li><a href="#route13">Route 13</a></li>
       <li><a href="#route14">Route 14</a></li>
       <li><a href="#route15">Route 15</a></li>
@@ -624,6 +628,60 @@
         <br />
     </div>
 
+    <div id="malie-city">
+        <h3><a href="#malie-city">Malie City</a></h3>
+        <p>Ula'ula Island</p>
+
+        <h4>Outer cape</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
+        <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 20%<br />
+        <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 30%<br />
+        <input type="checkbox" value="trubish" /><span class="pkspr pkmn-trubish"></span> Trubish - 30%<br />
+        <div class="ally">
+            <input type="checkbox" value="garbodor" /><span class="pkspr pkmn-garbodor"></span> Garbodor - Ally ^<br />
+        </div>
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 20% (D)<br />
+        <br />
+
+    </div>
+
+    <div id="malie-garden">
+        <h3><a href="#malie-garden">Malie Garden</a></h3>
+        <p>Ula'ula Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 20%<br />
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 10%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 20%<br />
+        <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
+        <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
+        <input type="checkbox" value="masquerain" /><span class="pkspr pkmn-masquerain"></span> Masquerain - 20% (N)<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10%<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10%<br />
+        <input type="checkbox" value="araquanid" /><span class="pkspr pkmn-araquanid"></span> Araquanid - 20%<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="poliwhirl" /><span class="pkspr pkmn-poliwhirl"></span> Poliwhirl - In rain - ~10%<br />
+            <input type="checkbox" value="poliwrath" /><span class="pkspr pkmn-poliwrath"></span> Poliwrath - In rain - ~1% (D)<br />
+            <input type="checkbox" value="politoed" /><span class="pkspr pkmn-politoed"></span> Politoed - In rain - ~1% (N)<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Hail or sandstorm - ~10%<br />
+        </div>
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="goldeen" /><span class="pkspr pkmn-goldeen"></span> Goldeen - 60%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="seaking" /><span class="pkspr pkmn-seaking"></span> Seaking - Ally ^<br />
+        </div>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 40%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
       <p>Ula'ula Island</p>
@@ -645,6 +703,23 @@
 
       <br />
     </div>
+
+    <div id="mount-hokulani">
+        <h3><a href="#mount-hokulani">Mount Hokulani</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 40%(D), 30% (N)<br />
+        <input type="checkbox" value="ditto" /><span class="pkspr pkmn-ditto"></span> Ditto - 10%<br />
+        <input type="checkbox" value="cleffa" /><span class="pkspr pkmn-cleffa"></span> Cleffa - 10% (N)<br />
+        <div class="ally">
+            <input type="checkbox" value="clefairy" /><span class="pkspr pkmn-clefairy"></span> Clefairy - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="skarmory" /><span class="pkspr pkmn-skarmory"></span> Skarmory - 10%<br />
+        <input type="checkbox" value="beldum" /><span class="pkspr pkmn-beldum"></span> Beldum - 10%<br />
+        <input type="checkbox" value="minior" /><span class="pkspr pkmn-minior"></span> Minior - 30%<br />
+        <br />
+    </div>
+
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
       <p>Ula'ula Island</p>
@@ -682,6 +757,24 @@
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br />
       <br />
     </div>
+
+    <div id="blush-mountain">
+      <h3><a href="#blush-mountain">Blush Mountain</a></h3>
+      <p>Ula'ula Island</p>
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 30%<br />
+          <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
+          <div class="ally">
+            <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+          </div>
+          <input type="checkbox" value="torkoal" /><span class="pkspr pkmn-torkoal"></span> Torkoal - 10% or 20%<br />
+          <input type="checkbox" value="charjabug" /><span class="pkspr pkmn-charjabug"></span> Charjabug - 10%<br />
+          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 20%<br />
+          <input type="checkbox" value="turtonator" /><span class="pkspr pkmn-turtonator"></span> Turtonator - 10%<br />
+          <input type="checkbox" value="togedemaru" /><span class="pkspr pkmn-togedemaru"></span> Togedemaru - 10%<br />
+      <br />
+    </div>
+
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
       <p>Ula'ula Island</p>
@@ -701,6 +794,7 @@
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
       <br />
     </div>
+
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
       <p>Ula'ula Island</p>

--- a/index.html
+++ b/index.html
@@ -35,11 +35,18 @@
       <li><a href="#seward-cave">Seaward Cave</a></li>
       <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
+      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
       <li><a href="#route5">Route 5</a></li>
+      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
+      <li><a href="#lush-jungle">Lush Jungle</a></li>
       <li><a href="#route6">Route 6</a></li>
       <li><a href="#route7">Route 7</a></li>
+      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
       <li><a href="#route8">Route 8</a></li>
       <li><a href="#route9">Route 9</a></li>
+      <li><a href="#memorial-hill">Memorial Hill</a></li>
+      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
+      <li><a href="#hano-beach">Hano Beach</a></li>
       <li><a href="#route10">Route 10</a></li>
       <li><a href="#route11">Route 11</a></li>
       <li><a href="#route12">Route 12</a></li>
@@ -223,8 +230,8 @@
             </div>
             <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
             <div class="ally">
-                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
-                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - Ally ^<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
             </div>
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
             <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
@@ -307,6 +314,21 @@
         <input type="checkbox" value="venipede" /><span class="pkspr pkmn-venipede"></span> Venipede - One (IS)<br />
       <br />
     </div>
+    <div id="paniola-ranch">
+      <h3><a href="#paniola-ranch">Paniola Ranch</a></h3>
+      <p>Akala Island</p>
+        <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 5%<br />
+          <div class="ally">
+            <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+          </div>
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
+          <div class="ally">
+              <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+          </div>
+          <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
+          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
+          <br />
+    </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
       <p>Akala Island</p>
@@ -335,6 +357,124 @@
           <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br />
           <input type="checkbox" value="bellsprout" /><span class="pkspr pkmn-bellsprout"></span> Bellsprout - One (IS)<br />
       <br />
+    </div>
+    <div id="brooklet-hill">
+        <h3><a href="#brooklet-hill">Brooklet Hill</a></h3>
+        <p>Akala Island</p>
+
+        <h4>First field of grass</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 20% (D)<br />
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 30%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 10%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 10%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 10% (N)<br />
+        <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lillipup - 20%<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 10% (D)<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 20% (N)<br />
+        <br />
+
+        <h4>Field of grass across second lake</h4>
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 30%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 20%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 30%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 20% (N)<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 20% (D)<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 40%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 40% (N)<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 40% (D)<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="goldeen" /><span class="pkspr pkmn-goldeen"></span> Goldeen - 29%, 45% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="seaking" /><span class="pkspr pkmn-seaking"></span> Seaking - Ally ^<br />
+        </div>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 70%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="feebas" /><span class="pkspr pkmn-feebas"></span> Feebas - 1%, 5% @ bubble spot<br />
+        <br />
+
+    </div>
+    <div id="lush-jungle">
+        <h3><a href="#lush-jungle">Lush Jungle</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Central area</h4>
+        <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+        </div>
+        <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - Ally ^<br />
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 20% (D)<br />
+        <input type="checkbox" value="bonsly" /><span class="pkspr pkmn-bonsly"></span> Bonsly - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="sudowoodo" /><span class="pkspr pkmn-sudowoodo"></span> Sudowoodo - Ally ^<br />
+            <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 20% (N)<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
+        <h4>Northwest area</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%, Ambush 100%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 10% (N)<br />
+        <input type="checkbox" value="bounsweet" /><span class="pkspr pkmn-bounsweet"></span> Bounsweet - 40%<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
+        <h4>North area</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 30% (D)<br />
+        <input type="checkbox" value="pinsir" /><span class="pkspr pkmn-pinsir"></span> Pinsir - 10%<br />
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 30%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 30% (N)<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
@@ -378,6 +518,20 @@
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
       <br />
     </div>
+    <div id="wela-volcano-park">
+        <h3><a href="#wela-volcano-park">Wela Volcano Park</a></h3>
+        <p>Akala Island</p>
+
+          <input type="checkbox" value="cubone" /><span class="pkspr pkmn-cubone"></span> Cubone - 24%<br />
+          <div class="ally">
+              <input type="checkbox" value="kangaskhan" /><span class="pkspr pkmn-kangaskhan"></span> Kangaskhan - Ally ^<br />
+          </div>
+          <input type="checkbox" value="kangaskhan" /><span class="pkspr pkmn-kangaskhan"></span> Kangaskhan - 1%<br />
+          <input type="checkbox" value="magby" /><span class="pkspr pkmn-magby"></span> Magby - 15%<br />
+          <input type="checkbox" value="fletchling" /><span class="pkspr pkmn-fletchling"></span> Fletchling - 30%<br />
+          <input type="checkbox" value="salandit" /><span class="pkspr pkmn-salandit"></span> Salandit - 30%<br />
+          <br />
+    </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
       <p>Akala Island</p>
@@ -420,6 +574,56 @@
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
       <br />
     </div>
+
+    <div id="memorial-hill">
+        <h3><a href="#memorial-hill">Memorial Hill</a></h3>
+        <p>Akala island</p>
+        <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+        <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+        <input type="checkbox" value="phantump" /><span class="pkspr pkmn-phantump"></span>Phantump - 30%<br />
+        <br />
+    </div>
+
+    <div id="akala-outskirts">
+        <h3><a href="#akala-outskirts">Akala Outskirts</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 50%<br />
+        <input type="checkbox" value="nosepass" /><span class="pkspr pkmn-nosepass"></span> Nosepass - 15%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="stufful" /><span class="pkspr pkmn-stufful"></span> Stufful - 5%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 60% @ fishing spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="chinchou" /><span class="pkspr pkmn-chinchou"></span> Chinchou - 1%, 20% @ fishing spot<br />
+        <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 20% @ fishing spot<br />
+        <br />
+    </div>
+
+    <div id="hano-beach">
+        <h3><a href="#hano-beach">Hano Beach</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Ambush encounters</h4>
+        <input type="checkbox" value="staryu" /><span class="pkspr pkmn-staryu"></span> Staryu - 80% @ sand cloud<br />
+        <input type="checkbox" value="sandygast" /><span class="pkspr pkmn-sandygast"></span> Sandygast - 20% @ sand cloud<br />
+        <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 100% @ splash water<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+        <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 30%<br />
+        <input type="checkbox" value="pyukumuku" /><span class="pkspr pkmn-pyukumuku"></span> Pyukumuku - 20%<br />
+        <br />
+    </div>
+
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
       <p>Ula'ula Island</p>
@@ -575,12 +779,12 @@
           <input type="checkbox" value="pancham" /><span class="pkspr pkmn-pancham"></span> Pancham - 10%<br />
           <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br /><br />
           <div class="ally">
-            <h5>Special allies in weather</h5>
+              <h5>Special allies in weather</h5>
               <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
               <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - ~10%<br />
-            </div>
+          </div>
       <br />
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,9 @@
   <div class="main">
     <ul>
       <li><a href="#route1">Route 1</a></li>
+      <li><a href="#melemele-sea">Melemele Sea</a></li>
+      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+      <li><a href="#huoli-city">Hu'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
       <li><a href="#route3">Route 3</a></li>
       <li><a href="#route4">Route 4</a></li>
@@ -78,27 +81,6 @@
             <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
           </div>
           <br />
-        <h4>Ten Carat Hill</h4>
-        <h5>Cave and ocean Cave</h5>
-          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
-          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
-          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
-          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
-          <div class="ally">
-            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
-          </div>
-          <br />
-        <h5>Surfing</h5>
-          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
-          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
-          <br />
-        <h5>Farthest Hollow</h5>
-          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
-          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
-          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
-          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
-          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
-          <br />
         <h4>Hau'oli Outskirts</h4>
           <h5>Beachfront</h5>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -114,6 +96,85 @@
           <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 50%<br />
           <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 20%<br />
       <br />
+    </div>
+    <div id="ten-carat-hill">
+        <h3><a href="#ten-carat-hill">Ten Carat Hill</a></h3>
+        <p>Melemele Island</p>
+        <h4>Cave and ocean Cave</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Farthest Hollow</h4>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
+    </div>
+    <div id="melemele-sea">
+        <h3><a href="#melemele-sea"> Melemele Sea</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+        <h4>Fishing at a bubbling spot</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 20%<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 20%<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 40%<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+    </div>
+    <div id="huoli-city">
+        <h3><a href="#huoli-city">Hu'Oli City</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+        <h4>Shopping District</h4>
+            <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
+            <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
+            <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 25%<br />
+            <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 10%<br />
+            <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 10%<br />
+            <input type="checkbox" value="pichu" /><span class="pkspr pkmn-pichu"></span> Pichu - 5%<br />
+            <div class="ally">
+                <input type="checkbox" value="pikachu" /><span class="pkspr pkmn-pikachu"></span> Pikachu - Ally ^<br />
+                <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+            </div>
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 20% (D)<br />
+        <br />
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
@@ -285,7 +346,6 @@
           </div>
           <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 70%<br />
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
-
       <br />
     </div>
     <div id="route10">
@@ -331,7 +391,7 @@
       <h3><a href="#route12">Route 12</a></h3>
       <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
-          <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
           <div class="ally">
             <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
@@ -454,7 +514,7 @@
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
     PkSpr.process_dom();
@@ -482,7 +542,7 @@
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
   <br />
-<p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</p>.
+  <p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -23,57 +23,83 @@
 </head>
 <body>
   <div class="main">
-    <ul>
-      <li><a href="#route1">Route 1</a></li>
-      <li><a href="#melemele-sea">Melemele Sea</a></li>
-      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
-      <li><a href="#huaoli-city">Hau'oli City</a></li>
-      <li><a href="#route2">Route 2</a></li>
-      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
-      <li><a href="#route3">Route 3</a></li>
-      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
-      <li><a href="#seward-cave">Seaward Cave</a></li>
-      <li><a href="#kalae-bay">Kala'e Bay</a></li>
-      <li><a href="#route4">Route 4</a></li>
-      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
-      <li><a href="#route5">Route 5</a></li>
-      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
-      <li><a href="#lush-jungle">Lush Jungle</a></li>
-      <li><a href="#route6">Route 6</a></li>
-      <li><a href="#route7">Route 7</a></li>
-      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
-      <li><a href="#route8">Route 8</a></li>
-      <li><a href="#route9">Route 9</a></li>
-      <li><a href="#memorial-hill">Memorial Hill</a></li>
-      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
-      <li><a href="#hano-beach">Hano Beach</a></li>
-      <li><a href="#malie-city">Malie City</a></li>
-      <li><a href="#malie-garden">Malie Garden</a></li>
-      <li><a href="#route10">Route 10</a></li>
-      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
-      <li><a href="#route11">Route 11</a></li>
-      <li><a href="#route12">Route 12</a></li>
-      <li><a href="#blush-mountain">Blush Mountain</a></li>
-      <li><a href="#route13">Route 13</a></li>
-      <li><a href="#haina-desert">Haina Desert</a></li>
-      <li><a href="#tapu-village">Tapu Village</a></li>
-      <li><a href="#route14">Route 14</a></li>
-      <li><a href="#abandoned-site">Abandoned Site</a></li>
-      <li><a href="#route15">Route 15</a></li>
-      <li><a href="#route16">Route 16</a></li>
-      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
-      <li><a href="#route17">Route 17</a></li>
-      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
-      <li><a href="#seafolk-village">Seafolk Village</a></li>
-      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
-      <li><a href="#poni-wilds">Poni Wilds</a></li>
-      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
-      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
-      <li><a href="#poni-grove">Poni Grove</a></li>
-      <li><a href="#poni-plains">Poni Plains</a></li>
-      <li><a href="#poni-meadow">Poni Meadow</a></li>
-      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
-    </ul>
+      <nav>
+          <ul>
+              <li id="melemele-island">
+                  <a href="#melemele-island">Melemele Island</a>
+                  <ul>
+                      <li><a href="#route1">Route 1</a></li>
+                      <li><a href="#melemele-sea">Melemele Sea</a></li>
+                      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+                      <li><a href="#huaoli-city">Hau'oli City</a></li>
+                      <li><a href="#route2">Route 2</a></li>
+                      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
+                      <li><a href="#route3">Route 3</a></li>
+                      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+                      <li><a href="#seward-cave">Seaward Cave</a></li>
+                      <li><a href="#kalae-bay">Kala'e Bay</a></li>
+                  </ul>
+              </li>
+
+              <li id="akala-island">
+                  <a href="#akala-island">Akala Island</a>
+                  <ul>
+                      <li><a href="#route4">Route 4</a></li>
+                      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
+                      <li><a href="#route5">Route 5</a></li>
+                      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
+                      <li><a href="#lush-jungle">Lush Jungle</a></li>
+                      <li><a href="#route6">Route 6</a></li>
+                      <li><a href="#route7">Route 7</a></li>
+                      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
+                      <li><a href="#route8">Route 8</a></li>
+                      <li><a href="#route9">Route 9</a></li>
+                      <li><a href="#memorial-hill">Memorial Hill</a></li>
+                      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
+                      <li><a href="#hano-beach">Hano Beach</a></li>
+                  </ul>
+              </li>
+
+              <li id="ula-ula-island">
+                  <a href="#ula-ula-island">Ula'ula Island</span>
+                  <ul>
+                      <li><a href="#malie-city">Malie City</a></li>
+                      <li><a href="#malie-garden">Malie Garden</a></li>
+                      <li><a href="#route10">Route 10</a></li>
+                      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
+                      <li><a href="#route11">Route 11</a></li>
+                      <li><a href="#route12">Route 12</a></li>
+                      <li><a href="#blush-mountain">Blush Mountain</a></li>
+                      <li><a href="#route13">Route 13</a></li>
+                      <li><a href="#haina-desert">Haina Desert</a></li>
+                      <li><a href="#tapu-village">Tapu Village</a></li>
+                      <li><a href="#route14">Route 14</a></li>
+                      <li><a href="#abandoned-site">Abandoned Site</a></li>
+                      <li><a href="#route15">Route 15</a></li>
+                      <li><a href="#route16">Route 16</a></li>
+                      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
+                      <li><a href="#route17">Route 17</a></li>
+                      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
+                  </ul>
+              </li>
+
+              <li id="poni-island">
+                  <a href="#poni-island">Poni Island</a>
+                  <ul>
+                      <li><a href="#seafolk-village">Seafolk Village</a></li>
+                      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
+                      <li><a href="#poni-wilds">Poni Wilds</a></li>
+                      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
+                      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
+                      <li><a href="#poni-grove">Poni Grove</a></li>
+                      <li><a href="#poni-plains">Poni Plains</a></li>
+                      <li><a href="#poni-meadow">Poni Meadow</a></li>
+                      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
+                  </ul>
+              </li>
+
+          </ul>
+      </nav>
   <div class="center padding">
     <br>
     <br /><br />

--- a/index.html
+++ b/index.html
@@ -78,6 +78,27 @@
             <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
           </div>
           <br />
+        <h4>Ten Carat Hill</h4>
+        <h5>Cave and ocean Cave</h5>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h5>Surfing</h5>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h5>Farthest Hollow</h5>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
         <h4>Hau'oli Outskirts</h4>
           <h5>Beachfront</h5>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
             <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
             <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
-            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="oricorio-pom-pom" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
             <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
             <br />
     </div>
@@ -504,7 +504,7 @@
         <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 10% (D)<br />
         <input type="checkbox" value="grubbin" /><span class="pkspr pkmn-grubbin"></span> Grubbin - 10%<br />
         <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 20%<br />
-        <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pa-u"></span> Oricorio - 20%<br />
+        <input type="checkbox" value="oricorio-pa-u" /><span class="pkspr pkmn-oricorio form-pa-u"></span> Oricorio - 20%<br />
         <input type="checkbox" value="gothita" /><span class="pkspr pkmn-gothita"></span> Gothita - One (IS)<br />
       <br />
     </div>
@@ -920,7 +920,7 @@
           <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
         <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
         <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
-        <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
+        <input type="checkbox" value="oricorio-baile" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
         <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
         <br />
     </div>

--- a/night.html
+++ b/night.html
@@ -65,6 +65,15 @@
       <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
       <li><a href="#route17">Route 17</a></li>
       <li><a href="#mount-lanakila">Mount Lanakila</a></li>
+      <li><a href="#seafolk-village">Seafolk Village</a></li>
+      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
+      <li><a href="#poni-wilds">Poni Wilds</a></li>
+      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
+      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
+      <li><a href="#poni-grove">Poni Grove</a></li>
+      <li><a href="#poni-plains">Poni Plains</a></li>
+      <li><a href="#poni-meadow">Poni Meadow</a></li>
+      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
     </ul>
   <div class="center padding">
     <br>
@@ -107,11 +116,13 @@
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
             <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 50%<br />
-            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br /><br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+            <br />
           <h6>Surfing</h6>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
-            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
         <h4>Trainers' School</h4>
           <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
           <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 50%<br />
@@ -169,7 +180,8 @@
         <h4>Surfing</h4>
             <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
             <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
-            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
         <h4>Shopping District</h4>
             <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
             <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
@@ -225,7 +237,8 @@
             <input type="checkbox" value="salamence" /><span class="pkspr pkmn-salamence"></span> Salamence - Ally ^<br />
           </div>
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabwraler - 100% (Berry tree)<br />
-        <input type="checkbox" value="cyndaquil" /><span class="pkspr pkmn-cyndaquil"></span> Cyndaquil - One (IS)<br /><br />
+        <input type="checkbox" value="cyndaquil" /><span class="pkspr pkmn-cyndaquil"></span> Cyndaquil - One (IS)<br />
+        <br />
         <h5>Ambush encounters</h5>
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
@@ -244,8 +257,8 @@
                 <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
             </div>
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
-            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
-            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30% (Sun)<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30% (Moon)<br />
             <input type="checkbox" value="oricorio-pom-pom" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
             <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
             <br />
@@ -328,16 +341,16 @@
       <h3><a href="#paniola-ranch">Paniola Ranch</a></h3>
       <p>Akala Island</p>
         <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 5%<br />
-          <div class="ally">
+        <div class="ally">
             <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
-          </div>
-          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
-          <div class="ally">
-              <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
-          </div>
-          <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
-          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
-          <br />
+        </div>
+        <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
+        <div class="ally">
+            <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+        </div>
+        <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
+        <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
+        <br />
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
@@ -355,7 +368,8 @@
           <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 30%<br />
           <input type="checkbox" value="pikipek" /><span class="pkspr pkmn-pikipek"></span> pikipek - 20%<br />
           <input type="checkbox" value="grubbin" /><span class="pkspr pkmn-grubbin"></span> Grubbin - 10%<br />
-          <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br /><br />
+          <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br />
+          <br />
         <h4>Northern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 15%<br />
           <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 10%<br />
@@ -552,7 +566,7 @@
           <input type="checkbox" value="salandit" /><span class="pkspr pkmn-salandit"></span> Salandit - 20%<br />
           <input type="checkbox" value="stufful" /><span class="pkspr pkmn-stufful"></span> Stufful - 20%<br />
           <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% @ Berry Tree<br />
-          <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (AMB)<br /><br />
+          <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (AMB)<br />
           <input type="checkbox" value="luxio" /><span class="pkspr pkmn-luxio"></span> Luxio - One (IS)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
@@ -642,7 +656,7 @@
         <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
         <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 20%<br />
         <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 30%<br />
-        <input type="checkbox" value="trubish" /><span class="pkspr pkmn-trubish"></span> Trubish - 30%<br />
+        <input type="checkbox" value="trubbish" /><span class="pkspr pkmn-trubbish"></span> Trubbish - 30%<br />
         <div class="ally">
             <input type="checkbox" value="garbodor" /><span class="pkspr pkmn-garbodor"></span> Garbodor - Ally ^<br />
         </div>
@@ -662,8 +676,8 @@
         <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
         <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
         <input type="checkbox" value="masquerain" /><span class="pkspr pkmn-masquerain"></span> Masquerain - 20% (N)<br />
-        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10%<br />
-        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10%<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10% (Moon)<br />
         <input type="checkbox" value="araquanid" /><span class="pkspr pkmn-araquanid"></span> Araquanid - 20%<br />
         <br />
         <div class="ally">
@@ -919,8 +933,8 @@
         <p>Ula'ula Island</p>
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
           <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
-        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
-        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30% (Moon)<br />
         <input type="checkbox" value="oricorio-baile" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
         <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
         <br />
@@ -989,44 +1003,350 @@
       <input type="checkbox" value="drampa" /><span class="pkspr pkmn-drampa"></span> Drampa - 10% (Moon)<br />
       <br />
     </div>
+
+    <div id="seafolk-village">
+        <h3><a href="#seafolk-village">Seafolk Village</a></h3>
+        <p>Poni Island</p>
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dhelmise" /><span class="pkspr pkmn-dhelmise"></span> Dhelmise - 1%, 10% @ bubble spot<br />
+        <br />
+    </div>
+
+    <div id="exeggutor-island">
+        <h3><a href="#exeggutor-island">Exeggutor Island</a></h3>
+        <p>Poni Island</p>
+        <input type="checkbox" value="exeggcute" /><span class="pkspr pkmn-exeggcute"></span> Exeggcute - 40%<br />
+        <input type="checkbox" value="exeggutor" /><span class="pkspr pkmn-exeggutor form-alola"></span> Exeggutor - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 10%<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="sliggoo" /><span class="pkspr pkmn-sliggoo"></span> Sliggoo - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-wilds">
+        <h3><a href="#poni-wilds">Poni Wilds</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="exeggcute" /><span class="pkspr pkmn-exeggcute"></span> Exeggcute - 10%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 10%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (Ambush - chase)<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="tentacruel" /><span class="pkspr pkmn-tentacruel"></span> Tentacruel - 10% or 20%<br />
+        <div class="ally">
+            <input type="checkbox" value="lumineon" /><span class="pkspr pkmn-lumineon"></span> Lumineon - Ally ^<br />
+        </div>
+        <input type="checkbox" value="lapras" /><span class="pkspr pkmn-lapras"></span> Lapras - 5%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
+        <input type="checkbox" value="gastrodon" /><span class="pkspr pkmn-gastrodon form-east"></span> Gastrodon (East-sea form) - 20%<br />
+        <input type="checkbox" value="lumineon" /><span class="pkspr pkmn-lumineon"></span> Lumineon - 25%<br />
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 90% (Ambush - water splash) <br />
+        <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - 10% (Ambush - water splash) <br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <input type="checkbox" value="relicanth" /><span class="pkspr pkmn-relicanth"></span> Relicanth - 1%, 10% @ bubble spot<br />
+        <br />
+    </div>
+
+    <div id="vast-poni-canyon">
+        <h3><a href="#vast-poni-canyon">Vast Poni Canyon</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Outside</h4>
+        <input type="checkbox" value="machoke" /><span class="pkspr pkmn-machoke"></span> Machoke - 30%<br />
+        <input type="checkbox" value="murkrow" /><span class="pkspr pkmn-murkrow"></span> Murkrow - 10%<br />
+        <input type="checkbox" value="skarmory" /><span class="pkspr pkmn-skarmory"></span> Skarmory - 10%<br />
+        <input type="checkbox" value="boldore" /><span class="pkspr pkmn-boldore"></span> Boldore - 10%<br />
+        <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 15%<br />
+        <input type="checkbox" value="lycanroc-day" /><span class="pkspr pkmn-lycanroc form-midday"></span> Lycanroc (Midday form) - 20% (D)<br />
+        <input type="checkbox" value="lycanroc-night" /><span class="pkspr pkmn-lycanroc form-midnight"></span> Lycanroc (Midnight form) - 20% (N)<br />
+        <input type="checkbox" value="jangmo-o" /><span class="pkspr pkmn-jangmo-o"></span> Jangmo-o - 5%<br />
+        <div class="ally">
+            <input type="checkbox" value="kommo-o" /><span class="pkspr pkmn-kommo-o"></span> Kommo-o - Ally ^<br />
+            <input type="checkbox" value="hakamo-o" /><span class="pkspr pkmn-hakamo-o"></span> Hakamo-o - Ally ^^<br />
+        </div>
+        <br />
+
+        <h4>Caves</h4>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 30%<br />
+        <input type="checkbox" value="dugtrio" /><span class="pkspr pkmn-dugtrio form-alola"></span> Dugtrio - 30%, 100% @ Ambush<br />
+        <input type="checkbox" value="boldore" /><span class="pkspr pkmn-boldore"></span> Boldore - 30%<br />
+        <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 80%<br />
+        <input type="checkbox" value="golduck" /><span class="pkspr pkmn-golduck"></span> Golduck - 20%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-breaker">
+        <h3><a href="#poni-breaker">Poni Breaker Coast</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Ambush Encounters</h4>
+        <input type="checkbox" value="wimpod" /><span class="pkspr pkmn-wimpod"></span> Wimpod - 100% (Ambush - chase)<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="sharpedo" /><span class="pkspr pkmn-sharpedo"></span> Sharpedo - 1%, 10% @ bubble spot<br />
+        <input type="checkbox" value="wailmer" /><span class="pkspr pkmn-wailmer"></span> Wailmer - 20%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="wailord" /><span class="pkspr pkmn-wailord"></span> Wailord - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-grove">
+        <h3><a href="#poni-grove">Poni Grove</a></h3>
+        <p>Poni Island</p>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="pinsir" /><span class="pkspr pkmn-pinsir"></span> Pinsir - 10%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="riolu" /><span class="pkspr pkmn-riolu"></span> Riolu - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="lucario" /><span class="pkspr pkmn-lucario"></span> Lucario - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <br />
+    </div>
+
+    <div id="poni-plains">
+      <h3><a href="#poni-plains">Poni Plains</a></h3>
+      <p>Poni Island</p>
+
+      <h4>7 small fields of grass scattered in the middle</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>2 large fields in the north and around central tree</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="hypno" /><span class="pkspr pkmn-hypno"></span> Hypno - 20%<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>2 fields of grass by the mountain</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 10% (N)<br />
+      <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 20%<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 10% (D)<br />
+      <input type="checkbox" value="mudsdale" /><span class="pkspr pkmn-mudsdale"></span> Mudsdale - 20%<br />
+      <br />
+
+      <h4>3 fields of grass by the coastline</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+      <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+      </div>
+      <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 10%<br />
+      <div class="ally">
+          <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+      </div>
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 20% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 20% (Moon)<br />
+      <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 10%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Grass</h4>
+      <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 70% (N)<br />
+      <input type="checkbox" value="hariyama" /><span class="pkspr pkmn-hariyama"></span> Hariyama - 30%<br />
+      <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 70% (D)<br />
+      <br />
+
+      <h4>Ambush Encounters - Shadow of Flying Pokemon</h4>
+      <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 70%<br />
+      <input type="checkbox" value="braviary" /><span class="pkspr pkmn-braviary"></span> Braviary - 30% (Sun)<br />
+      <input type="checkbox" value="mandibuzz" /><span class="pkspr pkmn-mandibuzz"></span> Mandibuzz - 30% (Moon)<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Tree</h4>
+      <input type="checkbox" value="primeape" /><span class="pkspr pkmn-primeape"></span> Primeape - 80%<br />
+      <input type="checkbox" value="emolga" /><span class="pkspr pkmn-emolga"></span> Emolga - 20%<br />
+      <br />
+
+      <h4>Ambush Encounters - Rustling Bushes</h4>
+      <input type="checkbox" value="scyther" /><span class="pkspr pkmn-scyther"></span> Scyther - 30%<br />
+      <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 70% (Sun)<br />
+      <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 70% (Moon)<br />
+      <br />
+
+    </div>
+
+    <div id="poni-meadow">
+        <h3><a href="#poni-meadow">Poni Meadow</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 50% (Sun)<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 50% (Moon)<br />
+        <input type="checkbox" value="oricorio-sensu" /><span class="pkspr pkmn-oricorio form-sensu"></span> Oricorio (Sensu style) - 20%<br />
+        <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="poni-gauntlet">
+        <h3><a href="#poni-gauntlet">Poni Gauntlet</a></h3>
+        <p>Poni Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="golduck" /><span class="pkspr pkmn-golduck"></span> Golduck - 15%<br />
+        <input type="checkbox" value="granbull" /><span class="pkspr pkmn-granbull"></span> Granbull - 20%<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="bewear" /><span class="pkspr pkmn-bewear"></span> Bewear - 5%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 59%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="dratini" /><span class="pkspr pkmn-dratini"></span> Dratini - 1%, 10% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="dragonair" /><span class="pkspr pkmn-dragonair"></span> Dragonair - Ally ^<br />
+        </div>
+        <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 40%, 40% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
   <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
-    PkSpr.process_dom();
+   PkSpr.process_dom();
   </script>
   <script>
-(function() {
-    var boxes = document.querySelectorAll("input[type='checkbox']");
-    for (var i = 0; i < boxes.length; i++) {
-        var box = boxes[i];
-        setupBox(box);
-    }
-    function setupBox(box) {
-        var storageId = "checkbox" + box.value;
-        var oldVal    = localStorage.getItem(storageId);
-        box.checked = oldVal === "true" ? true : false;
-        box.addEventListener("change", function() {
-            localStorage.setItem(storageId, this.checked);
-        });
-    }
-})();
-</script>
-  <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
-  <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
-  <script type="text/javascript">
-    PkSpr.process_dom();
+   (function() {
+       var boxes = document.querySelectorAll("input[type='checkbox']");
+       for (var i = 0; i < boxes.length; i++) {
+           var box = boxes[i];
+           setupBox(box);
+       }
+       function setupBox(box) {
+           var storageId = "checkbox" + box.value;
+           var oldVal    = localStorage.getItem(storageId);
+           box.checked = oldVal === "true" ? true : false;
+           box.addEventListener("change", function() {
+               localStorage.setItem(storageId, this.checked);
+           });
+       }
+   })();
   </script>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   <script src="js/save.js" type="text/javascript"></script>
   <script src="js/checkbox.js" type="text/javascript"></script>
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
-  <br />
-  <p class="padding">By <a href="giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="github.com/giacomolaw/pokefinder" target="_blank">Pokefinder contributors</a></p>.
+      <br />
+      <p class="padding">By <a href="http://giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="https://github.com/giacomolaw/pokefinder/graphs/contributors" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>

--- a/night.html
+++ b/night.html
@@ -48,14 +48,23 @@
       <li><a href="#memorial-hill">Memorial Hill</a></li>
       <li><a href="#akala-outskirts">Akala Outskirts</a></li>
       <li><a href="#hano-beach">Hano Beach</a></li>
+      <li><a href="#malie-city">Malie City</a></li>
+      <li><a href="#malie-garden">Malie Garden</a></li>
       <li><a href="#route10">Route 10</a></li>
+      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
       <li><a href="#route11">Route 11</a></li>
       <li><a href="#route12">Route 12</a></li>
+      <li><a href="#blush-mountain">Blush Mountain</a></li>
       <li><a href="#route13">Route 13</a></li>
+      <li><a href="#haina-desert">Haina Desert</a></li>
+      <li><a href="#tapu-village">Tapu Village</a></li>
       <li><a href="#route14">Route 14</a></li>
+      <li><a href="#abandoned-site">Abandoned Site</a></li>
       <li><a href="#route15">Route 15</a></li>
       <li><a href="#route16">Route 16</a></li>
+      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
       <li><a href="#route17">Route 17</a></li>
+      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
     </ul>
   <div class="center padding">
     <br>
@@ -237,7 +246,7 @@
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
             <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
             <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
-            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="oricorio-pom-pom" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
             <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
             <br />
     </div>
@@ -496,7 +505,7 @@
         <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 10% (D)<br />
         <input type="checkbox" value="grubbin" /><span class="pkspr pkmn-grubbin"></span> Grubbin - 10%<br />
         <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 20%<br />
-        <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pa-u"></span> Oricorio - 20%<br />
+        <input type="checkbox" value="oricorio-pa-u" /><span class="pkspr pkmn-oricorio form-pa-u"></span> Oricorio - 20%<br />
         <input type="checkbox" value="gothita" /><span class="pkspr pkmn-gothita"></span> Gothita - One (IS)<br />
       <br />
     </div>
@@ -625,6 +634,60 @@
         <br />
     </div>
 
+    <div id="malie-city">
+        <h3><a href="#malie-city">Malie City</a></h3>
+        <p>Ula'ula Island</p>
+
+        <h4>Outer cape</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
+        <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 20%<br />
+        <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 30%<br />
+        <input type="checkbox" value="trubish" /><span class="pkspr pkmn-trubish"></span> Trubish - 30%<br />
+        <div class="ally">
+            <input type="checkbox" value="garbodor" /><span class="pkspr pkmn-garbodor"></span> Garbodor - Ally ^<br />
+        </div>
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 20% (D)<br />
+        <br />
+
+    </div>
+
+    <div id="malie-garden">
+        <h3><a href="#malie-garden">Malie Garden</a></h3>
+        <p>Ula'ula Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 20%<br />
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 10%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 20%<br />
+        <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
+        <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
+        <input type="checkbox" value="masquerain" /><span class="pkspr pkmn-masquerain"></span> Masquerain - 20% (N)<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 10%<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 10%<br />
+        <input type="checkbox" value="araquanid" /><span class="pkspr pkmn-araquanid"></span> Araquanid - 20%<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="poliwhirl" /><span class="pkspr pkmn-poliwhirl"></span> Poliwhirl - In rain - ~10%<br />
+            <input type="checkbox" value="poliwrath" /><span class="pkspr pkmn-poliwrath"></span> Poliwrath - In rain - ~1% (D)<br />
+            <input type="checkbox" value="politoed" /><span class="pkspr pkmn-politoed"></span> Politoed - In rain - ~1% (N)<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Hail or sandstorm - ~10%<br />
+        </div>
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="goldeen" /><span class="pkspr pkmn-goldeen"></span> Goldeen - 60%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="seaking" /><span class="pkspr pkmn-seaking"></span> Seaking - Ally ^<br />
+        </div>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 40%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <br />
+    </div>
+
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
       <p>Ula'ula Island</p>
@@ -646,6 +709,23 @@
 
       <br />
     </div>
+
+    <div id="mount-hokulani">
+        <h3><a href="#mount-hokulani">Mount Hokulani</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 40%(D), 30% (N)<br />
+        <input type="checkbox" value="ditto" /><span class="pkspr pkmn-ditto"></span> Ditto - 10%<br />
+        <input type="checkbox" value="cleffa" /><span class="pkspr pkmn-cleffa"></span> Cleffa - 10% (N)<br />
+        <div class="ally">
+            <input type="checkbox" value="clefairy" /><span class="pkspr pkmn-clefairy"></span> Clefairy - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="skarmory" /><span class="pkspr pkmn-skarmory"></span> Skarmory - 10%<br />
+        <input type="checkbox" value="beldum" /><span class="pkspr pkmn-beldum"></span> Beldum - 10%<br />
+        <input type="checkbox" value="minior" /><span class="pkspr pkmn-minior"></span> Minior - 30%<br />
+        <br />
+    </div>
+
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
       <p>Ula'ula Island</p>
@@ -683,6 +763,24 @@
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br />
       <br />
     </div>
+
+    <div id="blush-mountain">
+      <h3><a href="#blush-mountain">Blush Mountain</a></h3>
+      <p>Ula'ula Island</p>
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 30%<br />
+          <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
+          <div class="ally">
+            <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
+            <input type="checkbox" value="chansey" /><span class="pkspr pkmn-chansey"></span> Chansey - Ally ^^<br />
+          </div>
+          <input type="checkbox" value="torkoal" /><span class="pkspr pkmn-torkoal"></span> Torkoal - 10% or 20%<br />
+          <input type="checkbox" value="charjabug" /><span class="pkspr pkmn-charjabug"></span> Charjabug - 10%<br />
+          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 20%<br />
+          <input type="checkbox" value="turtonator" /><span class="pkspr pkmn-turtonator"></span> Turtonator - 10% (Sun)<br />
+          <input type="checkbox" value="togedemaru" /><span class="pkspr pkmn-togedemaru"></span> Togedemaru - 10%<br />
+      <br />
+    </div>
+
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
       <p>Ula'ula Island</p>
@@ -702,12 +800,52 @@
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
       <br />
     </div>
+
+    <div id="haina-desert">
+        <h3><a href="#haina-desert">Haina Desert</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="dugtrio" /><span class="pkspr pkmn-dugtrio form-alola"></span> Dugtrio - 30%, 20% @ Ambush<br />
+        <input type="checkbox" value="sandile" /><span class="pkspr pkmn-sandile form-alola"></span> Sandile - 70% <br />
+        <input type="checkbox" value="trapinch" /><span class="pkspr pkmn-trapinch form-alola"></span> Trapinch - 10% @ Ambush<br />
+        <br />
+
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="gabite" /><span class="pkspr pkmn-gabite"></span> Gabite - Sandstorm - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Sandstorm - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Hail ~10%<br />
+        </div>
+        <br />
+    </div>
+
+    <div id="tapu-village">
+        <p>Ula'ula Island</p>
+        <h3><a href="#tapu-village">Tapu Village</a></h3>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="sandshrew" /><span class="pkspr pkmn-sandshrew form-alola"></span> Sandshrew - 10% (Moon)<br />
+        <input type="checkbox" value="vulpix" /><span class="pkspr pkmn-vulpix form-alola"></span> Vulpix - 10% (Sun)<br />
+        <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 30%<br />
+        <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 10%<br />
+        <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 20%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="vanillite" /><span class="pkspr pkmn-vanillite"></span> Vanillite - In hail - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Sandstorm ~10%<br />
+        </div>
+        <br />
+    </div>
+
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
       <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
-          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
+          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br /><br />
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
@@ -722,6 +860,20 @@
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
       <br />
     </div>
+
+    <div id="abandoned-site">
+        <h3><a href="#abandoned-site">Abandoned Site</a></h3>
+        <p>Ula'ula Island</p>
+        <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 40%<br />
+        <input type="checkbox" value="haunter" /><span class="pkspr pkmn-haunter"></span>Haunter - 40%<br />
+        <div class="ally">
+            <input type="checkbox" value="gengar" /><span class="pkspr pkmn-gengar"></span>Gengar - Ally ^<br />
+        </div>
+        <input type="checkbox" value="klefki" /><span class="pkspr pkmn-klefki"></span>Klefki - 15%<br />
+        <input type="checkbox" value="mimikyu" /><span class="pkspr pkmn-mimikyu"></span>Mimikyu - 5%<br />
+        <br />
+    </div>
+
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
       <p>Ula'ula Island</p>
@@ -731,7 +883,7 @@
           <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
-          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
+          <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 20%<br />
           <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 30%<br /><br />
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
@@ -745,9 +897,11 @@
           <div class="ally">
             <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
           </div>
-          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 30%<br /><br />
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 30%<br />
           <input type="checkbox" value="bruxish" /><span class="pkspr pkmn-bruxish"></span> Bruxish - 20%<br />
+          <br />
     </div>
+
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
       <p>Ula'ula Island</p>
@@ -759,6 +913,19 @@
           <input type="checkbox" value="duosion" /><span class="pkspr pkmn-duosion"></span> Duosion - One (IS)<br />
       <br />
     </div>
+
+    <div id="ulaula-meadow">
+        <h3><a href="#ulaula-meadow">Ula'ula Meadow</a></h3>
+        <p>Ula'ula Island</p>
+          <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
+          <input type="checkbox" value="ariados" /><span class="pkspr pkmn-ariados"></span> Ariados - 20% (N)<br />
+        <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+        <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+        <input type="checkbox" value="oricorio-baile" /><span class="pkspr pkmn-oricorio form-baile"></span> Oricorio (Baile style) - 20%<br />
+        <input type="checkbox" value="ribombee" /><span class="pkspr pkmn-ribombee"></span> Ribombee - 30%<br />
+        <br />
+    </div>
+
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
       <p>Ula'ula Island</p>
@@ -786,6 +953,40 @@
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - ~10%<br />
           </div>
+      <br />
+    </div>
+
+    <div id="mount-lanakila">
+      <h3><a href="#mount-lanakila">Mount Lanakila</a></h3>
+
+      <h4>Grass</h4>
+      <input type="checkbox" value="sandshrew" /><span class="pkspr pkmn-sandshrew form-alola"></span> Sandshrew - 30% (Moon)<br />
+      <input type="checkbox" value="vulpix" /><span class="pkspr pkmn-vulpix form-alola"></span> Vulpix - 30% (Sun)<br />
+      <input type="checkbox" value="sneasel" /><span class="pkspr pkmn-sneasel"></span> Sneasel - 20%<br />
+      <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 20%<br />
+      <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 30%<br />
+      <div class="ally">
+          <input type="checkbox" value="glalie" /><span class="pkspr pkmn-glalie"></span> Glalie - Ally ^<br />
+      </div>
+      <br />
+      <div class="ally">
+          <h5>Special allies in weather</h5>
+          <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+          <input type="checkbox" value="vanillish" /><span class="pkspr pkmn-vanillish"></span> Vanillish - In hail - ~10%<br />
+          <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail - ~1%<br />
+          <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - Rain or Sandstorm ~10%<br />
+      </div>
+      <br />
+
+      <h4>Cave</h4>
+      <input type="checkbox" value="golbat" /><span class="pkspr pkmn-golbat"></span>Golbat - 30%<br />
+      <input type="checkbox" value="sneasel" /><span class="pkspr pkmn-sneasel"></span> Sneasel - 20%<br />
+      <input type="checkbox" value="absol" /><span class="pkspr pkmn-absol"></span> Absol - 10% or 20%<br />
+      <input type="checkbox" value="snorunt" /><span class="pkspr pkmn-snorunt"></span> Snorunt - 30%<br />
+      <div class="ally">
+          <input type="checkbox" value="glalie" /><span class="pkspr pkmn-glalie"></span> Glalie - Ally ^<br />
+      </div>
+      <input type="checkbox" value="drampa" /><span class="pkspr pkmn-drampa"></span> Drampa - 10% (Moon)<br />
       <br />
     </div>
   </div>

--- a/night.html
+++ b/night.html
@@ -52,6 +52,7 @@
     <p><b>AMB</b> means ambush encounter, and <b>IS</b> means Island Scan. <b>Ally Pokemon</b> that are different to the original caller are highlighted in orange, and are below the caller.</p>
     <div id="route1">
       <h3><a href="#route1">Route 1</a></h3>
+      <p>Melemele Island</p>
         <h4>Proper</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 30%<br />
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 30% (N)<br />
@@ -95,6 +96,7 @@
     </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 30%<br />
         <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 20%<br />
@@ -111,6 +113,7 @@
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
+      <p>Melemele Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="spearow" /><span class="pkspr pkmn-spearow"></span> Spearow - 40%<br />
         <input type="checkbox" value="mankey" /><span class="pkspr pkmn-mankey"></span> Mankey - 20%<br />
@@ -130,6 +133,7 @@
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -151,6 +155,7 @@
     </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
+      <p>Akala Island</p>
         <h4>Southern half</h4>
           <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
           <div class="ally">
@@ -179,6 +184,7 @@
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 10% (N)<br />
         <input type="checkbox" value="eevee" /><span class="pkspr pkmn-eevee"></span> Eevee - 5%<br />
           <div class="ally">
@@ -201,6 +207,7 @@
     </div>
     <div id="route7">
       <h3><a href="#route7">Route 7</a></h3>
+      <p>Akala Island</p>
         <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br /><br />
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
@@ -219,6 +226,7 @@
     </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
+      <p>Akala Island</p>
           <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
           <input type="checkbox" value="fletchinder" /><span class="pkspr pkmn-fletchinder"></span> Fletchinder - 15%<br />
           <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 30%<br />
@@ -244,6 +252,7 @@
     </div>
     <div id="route9">
       <h3><a href="#route9">Route 9</a></h3>
+      <p>Akala Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 15%<br />
           <div class="ally">
@@ -260,6 +269,7 @@
     </div>
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -280,6 +290,7 @@
     </div>
     <div id="route11">
       <h3><a href="#route11">Route 11</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 20% (N)<br />
           <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />
@@ -297,6 +308,7 @@
     </div>
     <div id="route12">
       <h3><a href="#route12">Route 12</a></h3>
+      <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
           <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
@@ -315,6 +327,7 @@
     </div>
     <div id="route13">
       <h3><a href="#route13">Route 13</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Fishing</h5>
           <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%<br />
           <div class="ally">
@@ -333,6 +346,7 @@
     </div>
     <div id="route14">
       <h3><a href="#route14">Route 14</a></h3>
+      <p>Ula'ula Island</p>
         <h5>Surfing</h5>
           <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelippper - 20%<br />
@@ -352,6 +366,7 @@
     </div>
     <div id="route15">
       <h3><a href="#route15">Route 15</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -377,6 +392,7 @@
     </div>
     <div id="route16">
       <h3><a href="#route16">Route 16</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
           <input type="checkbox" value="pelipper" /><span class="pkspr pkmn-pelipper"></span> Pelipper - 50%<br />
@@ -387,6 +403,7 @@
     </div>
     <div id="route17">
       <h3><a href="#route17">Route 17</a></h3>
+      <p>Ula'ula Island</p>
           <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
           <input type="checkbox" value="fearow" /><span class="pkspr pkmn-fearow"></span> Fearow - 30%<br />
           <input type="checkbox" value="ledian" /><span class="pkspr pkmn-ledian"></span> Ledian - 20% (D)<br />

--- a/night.html
+++ b/night.html
@@ -36,11 +36,18 @@
       <li><a href="#seward-cave">Seaward Cave</a></li>
       <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
+      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
       <li><a href="#route5">Route 5</a></li>
+      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
+      <li><a href="#lush-jungle">Lush Jungle</a></li>
       <li><a href="#route6">Route 6</a></li>
       <li><a href="#route7">Route 7</a></li>
+      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
       <li><a href="#route8">Route 8</a></li>
       <li><a href="#route9">Route 9</a></li>
+      <li><a href="#memorial-hill">Memorial Hill</a></li>
+      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
+      <li><a href="#hano-beach">Hano Beach</a></li>
       <li><a href="#route10">Route 10</a></li>
       <li><a href="#route11">Route 11</a></li>
       <li><a href="#route12">Route 12</a></li>
@@ -224,8 +231,8 @@
             </div>
             <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
             <div class="ally">
-                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
-                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - Ally ^<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
             </div>
             <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
             <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
@@ -308,6 +315,21 @@
         <input type="checkbox" value="venipede" /><span class="pkspr pkmn-venipede"></span> Venipede - One (IS)<br />
       <br />
     </div>
+    <div id="paniola-ranch">
+      <h3><a href="#paniola-ranch">Paniola Ranch</a></h3>
+      <p>Akala Island</p>
+        <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - 5%<br />
+          <div class="ally">
+            <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - Ally ^<br />
+          </div>
+          <input type="checkbox" value="miltank" /><span class="pkspr pkmn-miltank"></span> Miltank - 5%<br />
+          <div class="ally">
+              <input type="checkbox" value="tauros" /><span class="pkspr pkmn-tauros"></span> Tauros - Ally ^<br />
+          </div>
+          <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lilipup - 40%<br />
+          <input type="checkbox" value="mudbray" /><span class="pkspr pkmn-mudbray"></span> Mudbray - 50%<br />
+          <br />
+    </div>
     <div id="route5">
       <h3><a href="#route5">Route 5</a></h3>
       <p>Akala Island</p>
@@ -336,6 +358,124 @@
           <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 100% (AMB)<br />
           <input type="checkbox" value="bellsprout" /><span class="pkspr pkmn-bellsprout"></span> Bellsprout - One (IS)<br />
       <br />
+    </div>
+    <div id="brooklet-hill">
+        <h3><a href="#brooklet-hill">Brooklet Hill</a></h3>
+        <p>Akala Island</p>
+
+        <h4>First field of grass</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 20% (D)<br />
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 30%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 10%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 10%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 10% (N)<br />
+        <input type="checkbox" value="lillipup" /><span class="pkspr pkmn-lillipup"></span> Lillipup - 20%<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 10% (D)<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 20% (N)<br />
+        <br />
+
+        <h4>Field of grass across second lake</h4>
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 30%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 20%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 30%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 20% (N)<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 20% (D)<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+        <input type="checkbox" value="poliwag" /><span class="pkspr pkmn-poliwag"></span> Poliwag - 40%<br />
+        <input type="checkbox" value="surskit" /><span class="pkspr pkmn-surskit"></span> Surskit - 40% (N)<br />
+        <input type="checkbox" value="dewpider" /><span class="pkspr pkmn-dewpider"></span> Dewpider - 40% (D)<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="goldeen" /><span class="pkspr pkmn-goldeen"></span> Goldeen - 29%, 45% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="seaking" /><span class="pkspr pkmn-seaking"></span> Seaking - Ally ^<br />
+        </div>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 70%, 50% @ bubble spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="feebas" /><span class="pkspr pkmn-feebas"></span> Feebas - 1%, 5% @ bubble spot<br />
+        <br />
+
+    </div>
+    <div id="lush-jungle">
+        <h3><a href="#lush-jungle">Lush Jungle</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Central area</h4>
+        <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+        </div>
+        <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - Ally ^<br />
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 20% (D)<br />
+        <input type="checkbox" value="bonsly" /><span class="pkspr pkmn-bonsly"></span> Bonsly - 10%<br />
+        <div class="ally">
+            <input type="checkbox" value="sudowoodo" /><span class="pkspr pkmn-sudowoodo"></span> Sudowoodo - Ally ^<br />
+            <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+        </div>
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 20% (N)<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
+        <h4>Northwest area</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 10% (D)<br />
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 20%, Ambush 100%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 10% (N)<br />
+        <input type="checkbox" value="bounsweet" /><span class="pkspr pkmn-bounsweet"></span> Bounsweet - 40%<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
+        <h4>North area</h4>
+        <input type="checkbox" value="paras" /><span class="pkspr pkmn-paras"></span> Paras - 30% (D)<br />
+        <input type="checkbox" value="pinsir" /><span class="pkspr pkmn-pinsir"></span> Pinsir - 10%<br />
+        <input type="checkbox" value="trumbeak" /><span class="pkspr pkmn-trumbeak"></span> Trumbeak - 20%<br />
+        <input type="checkbox" value="fomantis" /><span class="pkspr pkmn-fomantis"></span> Fomantis - 30%<br />
+        <input type="checkbox" value="morelull" /><span class="pkspr pkmn-morelull"></span> Morelull - 30% (N)<br />
+        <input type="checkbox" value="comfey" /><span class="pkspr pkmn-comfey"></span> Comfey - 5%<br />
+        <input type="checkbox" value="oranguru" /><span class="pkspr pkmn-oranguru"></span> Oranguru - 5% (Moon)<br />
+        <input type="checkbox" value="passimian" /><span class="pkspr pkmn-passimian"></span> Passimian - 5% (Sun)<br />
+        <br />
+        <div class="ally">
+            <h5>Special allies in weather</h5>
+            <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
+            <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
+            <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In hail or sandstorm ~10%<br />
+        </div>
+        <br />
+
     </div>
     <div id="route6">
       <h3><a href="#route6">Route 6</a></h3>
@@ -379,6 +519,20 @@
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
       <br />
     </div>
+    <div id="wela-volcano-park">
+        <h3><a href="#wela-volcano-park">Wela Volcano Park</a></h3>
+        <p>Akala Island</p>
+
+          <input type="checkbox" value="cubone" /><span class="pkspr pkmn-cubone"></span> Cubone - 24%<br />
+          <div class="ally">
+              <input type="checkbox" value="kangaskhan" /><span class="pkspr pkmn-kangaskhan"></span> Kangaskhan - Ally ^<br />
+          </div>
+          <input type="checkbox" value="kangaskhan" /><span class="pkspr pkmn-kangaskhan"></span> Kangaskhan - 1%<br />
+          <input type="checkbox" value="magby" /><span class="pkspr pkmn-magby"></span> Magby - 15%<br />
+          <input type="checkbox" value="fletchling" /><span class="pkspr pkmn-fletchling"></span> Fletchling - 30%<br />
+          <input type="checkbox" value="salandit" /><span class="pkspr pkmn-salandit"></span> Salandit - 30%<br />
+          <br />
+    </div>
     <div id="route8">
       <h3><a href="#route8">Route 8</a></h3>
       <p>Akala Island</p>
@@ -421,6 +575,56 @@
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
       <br />
     </div>
+
+    <div id="memorial-hill">
+        <h3><a href="#memorial-hill">Memorial Hill</a></h3>
+        <p>Akala island</p>
+        <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+        <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+        <input type="checkbox" value="phantump" /><span class="pkspr pkmn-phantump"></span>Phantump - 30%<br />
+        <br />
+    </div>
+
+    <div id="akala-outskirts">
+        <h3><a href="#akala-outskirts">Akala Outskirts</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Grass</h4>
+        <input type="checkbox" value="raticate" /><span class="pkspr pkmn-raticate form-alola"></span> Raticate - 30% (N)<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 50%<br />
+        <input type="checkbox" value="nosepass" /><span class="pkspr pkmn-nosepass"></span> Nosepass - 15%<br />
+        <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br />
+        <input type="checkbox" value="stufful" /><span class="pkspr pkmn-stufful"></span> Stufful - 5%<br />
+        <br />
+
+        <h4>Fishing</h4>
+        <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 60% @ fishing spot<br />
+        <div class="ally">
+            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+        </div>
+        <input type="checkbox" value="chinchou" /><span class="pkspr pkmn-chinchou"></span> Chinchou - 1%, 20% @ fishing spot<br />
+        <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 20% @ fishing spot<br />
+        <br />
+    </div>
+
+    <div id="hano-beach">
+        <h3><a href="#hano-beach">Hano Beach</a></h3>
+        <p>Akala Island</p>
+
+        <h4>Ambush encounters</h4>
+        <input type="checkbox" value="staryu" /><span class="pkspr pkmn-staryu"></span> Staryu - 80% @ sand cloud<br />
+        <input type="checkbox" value="sandygast" /><span class="pkspr pkmn-sandygast"></span> Sandygast - 20% @ sand cloud<br />
+        <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 100% @ splash water<br />
+        <br />
+
+        <h4>Surfing</h4>
+        <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 30%<br />
+        <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+        <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 30%<br />
+        <input type="checkbox" value="pyukumuku" /><span class="pkspr pkmn-pyukumuku"></span> Pyukumuku - 20%<br />
+        <br />
+    </div>
+
     <div id="route10">
       <h3><a href="#route10">Route 10</a></h3>
       <p>Ula'ula Island</p>
@@ -576,12 +780,12 @@
           <input type="checkbox" value="pancham" /><span class="pkspr pkmn-pancham"></span> Pancham - 10%<br />
           <input type="checkbox" value="gumshoos" /><span class="pkspr pkmn-gumshoos"></span> Gumshoos - 30% (D)<br /><br />
           <div class="ally">
-            <h5>Special allies in weather</h5>
+              <h5>Special allies in weather</h5>
               <p>These Pokemon can be allies to any Pokemon in certain weather conditions</p>
               <input type="checkbox" value="goomy" /><span class="pkspr pkmn-goomy"></span> Goomy - In rain - ~10%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - In rain - ~1%<br />
               <input type="checkbox" value="castform" /><span class="pkspr pkmn-castform"></span> Castform - ~10%<br />
-            </div>
+          </div>
       <br />
     </div>
   </div>

--- a/night.html
+++ b/night.html
@@ -23,10 +23,18 @@
   <!-- end -->
 </head>
 <body>
+  <div class="main">
     <ul>
       <li><a href="#route1">Route 1</a></li>
+      <li><a href="#melemele-sea">Melemele Sea</a></li>
+      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+      <li><a href="#huaoli-city">Hau'oli City</a></li>
       <li><a href="#route2">Route 2</a></li>
+      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
       <li><a href="#route3">Route 3</a></li>
+      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+      <li><a href="#seward-cave">Seaward Cave</a></li>
+      <li><a href="#kalae-bay">Kala'e Bay</a></li>
       <li><a href="#route4">Route 4</a></li>
       <li><a href="#route5">Route 5</a></li>
       <li><a href="#route6">Route 6</a></li>
@@ -94,6 +102,73 @@
           <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 20%<br />
       <br />
     </div>
+    <div id="ten-carat-hill">
+        <h3><a href="#ten-carat-hill">Ten Carat Hill</a></h3>
+        <p>Melemele Island</p>
+        <h4>Cave and ocean Cave</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 30%<br />
+          <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 20%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 30%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="sableye" /><span class="pkspr pkmn-sableye"></span> Sableye - Ally ^<br />
+          </div>
+          <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Farthest Hollow</h4>
+          <input type="checkbox" value="machop" /><span class="pkspr pkmn-machop"></span> Machop - 30%<br />
+          <input type="checkbox" value="spinda" /><span class="pkspr pkmn-spinda"></span> Spinda - 10%<br />
+          <input type="checkbox" value="roggenrola" /><span class="pkspr pkmn-roggenrola"></span> Roggenrola - 20%<br />
+          <input type="checkbox" value="carbink" /><span class="pkspr pkmn-carbink"></span> Carbink - 20%<br />
+          <input type="checkbox" value="rockruff" /><span class="pkspr pkmn-rockruff"></span> Rockruff - 20%<br />
+          <br />
+    </div>
+    <div id="melemele-sea">
+        <h3><a href="#melemele-sea"> Melemele Sea</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+            <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 78%, 20% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="corsola" /><span class="pkspr pkmn-corsola"></span> Corsola - 1%, 20% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="mareanie" /><span class="pkspr pkmn-mareanie"></span> Mareanie - Ally ^<br />
+            </div>
+            <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 1%, 40% @ bubble spot<br />
+            <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%<br />
+            <br />
+    </div>
+    <div id="huoli-city">
+        <h3><a href="#hauoli-city">Hau'oli City</a></h3>
+        <p>Melemele Island</p>
+        <h4>Surfing</h4>
+            <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br /><br />
+        <h4>Shopping District</h4>
+            <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Rattata - 20% (N)<br />
+            <input type="checkbox" value="meowth" /><span class="pkspr pkmn-meowth form-alola"></span> Meowth - 10%<br />
+            <input type="checkbox" value="abra" /><span class="pkspr pkmn-abra"></span> Abra - 25%<br />
+            <input type="checkbox" value="magnemite" /><span class="pkspr pkmn-magnemite"></span> Magnemite - 10%<br />
+            <input type="checkbox" value="grimer" /><span class="pkspr pkmn-grimer form-alola"></span> Grimer - 10%<br />
+            <input type="checkbox" value="pichu" /><span class="pkspr pkmn-pichu"></span> Pichu - 5%<br />
+            <div class="ally">
+                <input type="checkbox" value="pikachu" /><span class="pkspr pkmn-pikachu"></span> Pikachu - Ally ^<br />
+                <input type="checkbox" value="happiny" /><span class="pkspr pkmn-happiny"></span> Happiny - Ally ^^<br />
+            </div>
+            <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+            <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 20% (D)<br />
+        <br />
+    </div>
     <div id="route2">
       <h3><a href="#route2">Route 2</a></h3>
       <p>Melemele Island</p>
@@ -110,6 +185,15 @@
         <input type="checkbox" value="crabrawler" /><span class="pkspr pkmn-crabrawler"></span> Crabrawler - 100% (Berry tree)<br />
         <input type="checkbox" value="chikorita" /><span class="pkspr pkmn-chikorita"></span> Chikorita - One (IS)<br />
       <br />
+    </div>
+    <div id="hauoli-cemetery">
+        <h3><a href="#hauoli-cemetery">Hau'oli Cemetery</a></h3>
+        <p>Melemele Island</p>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 20%<br />
+          <input type="checkbox" value="gastly" /><span class="pkspr pkmn-gastly"></span>Gastly - 50%<br />
+          <input type="checkbox" value="misdreavus" /><span class="pkspr pkmn-misdreavus"></span>Misdreavus - 30% (N)<br />
+          <input type="checkbox" value="drifloon" /><span class="pkspr pkmn-drifloon"></span>Drifloon - 30% (D)<br />
+     <br />
     </div>
     <div id="route3">
       <h3><a href="#route3">Route 3</a></h3>
@@ -130,6 +214,77 @@
         <input type="checkbox" value="rufflet" /><span class="pkspr pkmn-rufflet"></span> Rufflet - 30% (Sun)<br />
         <input type="checkbox" value="vullaby" /><span class="pkspr pkmn-vullaby"></span> Vullaby - 30% (Moon)<br />
       <br />
+    </div>
+    <div id="melemele-meadow">
+        <h3><a href="#melemele-meadow">Melemele Meadow</a></h3>
+        <p>Melemele Island</p>
+            <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+            <div class="ally">
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="metapod" /><span class="pkspr pkmn-metapod"></span> Metapod - 9%<br />
+            <div class="ally">
+                <input type="checkbox" value="caterpie" /><span class="pkspr pkmn-caterpie"></span> Caterpie - 10%<br />
+                <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - Ally ^<br />
+            </div>
+            <input type="checkbox" value="butterfree" /><span class="pkspr pkmn-butterfree"></span> Butterfree - 1%<br />
+            <input type="checkbox" value="cottonee" /><span class="pkspr pkmn-cottonee"></span> Cottonee - 30%<br />
+            <input type="checkbox" value="petilil" /><span class="pkspr pkmn-petilil"></span> Petilil - 30%<br />
+            <input type="checkbox" value="oricorio" /><span class="pkspr pkmn-oricorio form-pom-pom"></span> Oricorio (Pom-pom style) - 20%<br />
+            <input type="checkbox" value="cutiefly" /><span class="pkspr pkmn-cutiefly"></span> Cutiefly - 30%<br />
+            <br />
+    </div>
+    <div id="seaward-cave">
+        <h3><a href="#seward-cave">Seaward Cave</a></h3>
+        <p>Melemele Island</p>
+        <h4>Walking</h4>
+            <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 70%<br />
+            <input type="checkbox" value="diglett" /><span class="pkspr pkmn-diglett form-alola"></span> Diglett - 30%<br />
+            <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="zubat" /><span class="pkspr pkmn-zubat"></span>Zubat - 80%<br />
+          <input type="checkbox" value="psyduck" /><span class="pkspr pkmn-psyduck"></span> Psyduck - 20%<br />
+          <br />
+        <h4>Fishing</h4>
+            <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 99%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+            </div>
+            <input type="checkbox" value="barboach" /><span class="pkspr pkmn-barboach"></span> Barboach - 1%, 50% @ bubble spot<br />
+            <div class="ally">
+                <input type="checkbox" value="whiscash" /><span class="pkspr pkmn-whiscash"></span> Whiscash - Ally ^<br />
+            </div>
+            <br />
+    </div>
+    <div id="kalae-bay">
+        <h3><a href="#kalae-bay">Kala'e Bay</a></h3>
+        <p>Melemele Island</p>
+        <h4>Grass</h4>
+          <input type="checkbox" value="rattata" /><span class="pkspr pkmn-rattata form-alola"></span> Ratata - 30% (N)<br />
+          <input type="checkbox" value="slowpoke" /><span class="pkspr pkmn-slowpoke"></span> Slowpoke - 20%<br />
+          <div class="ally">
+            <input type="checkbox" value="slowbro" /><span class="pkspr pkmn-slowbro"></span> Slowbro - Ally ^<br />
+          </div>
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 40%<br />
+          <input type="checkbox" value="bagon" /><span class="pkspr pkmn-bagon"></span> Bagon - 10%<br />
+          <div class="ally">
+              <input type="checkbox" value="shelgon" /><span class="pkspr pkmn-shelgon"></span> Shelgon - Ally ^<br />
+          </div>
+          <input type="checkbox" value="yungoos" /><span class="pkspr pkmn-yungoos"></span> Yungoos - 30% (D)<br />
+        <br />
+        <h4>Surfing</h4>
+          <input type="checkbox" value="tentacool" /><span class="pkspr pkmn-tentacool"></span> Tentacool - 40%<br />
+          <input type="checkbox" value="wingull" /><span class="pkspr pkmn-wingull"></span> Wingull - 20%<br />
+          <input type="checkbox" value="finneon" /><span class="pkspr pkmn-finneon"></span> Finneon - 40%<br />
+          <br />
+        <h4>Fishing</h4>
+          <input type="checkbox" value="shellder" /><span class="pkspr pkmn-shellder"></span> Shellder - 1%, 20% @ bubble spot<br />
+	          <input type="checkbox" value="magikarp" /><span class="pkspr pkmn-magikarp"></span> Magikarp - 79%, 50% @ bubble spot<br />
+	          <div class="ally">
+	            <input type="checkbox" value="gyarados" /><span class="pkspr pkmn-gyarados"></span> Gyarados - Ally ^<br />
+	          </div>
+          <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 20%, 30% @ bubble spot<br />
+          <br />
     </div>
     <div id="route4">
       <h3><a href="#route4">Route 4</a></h3>
@@ -264,7 +419,6 @@
           </div>
           <input type="checkbox" value="luvdisc" /><span class="pkspr pkmn-luvdisc"></span> Luvdisc - 70%<br />
           <input type="checkbox" value="wishiwashi" /><span class="pkspr pkmn-wishiwashi"></span> Wishiwashi - 10%<br />
-
       <br />
     </div>
     <div id="route10">
@@ -310,7 +464,7 @@
       <h3><a href="#route12">Route 12</a></h3>
       <p>Ula'ula Island</p>
         <h5>First ten fields of grass from the north</h5>
-          <input type="checkbox" value="geodude" /><class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
+          <input type="checkbox" value="geodude" /><span class="pkspr pkmn-geodude form-alola"></span> Geodude - 40%<br />
           <input type="checkbox" value="elekid" /><span class="pkspr pkmn-elekid"></span> Elekid - 10% <br />
           <div class="ally">
             <input type="checkbox" value="electabuzz" /><span class="pkspr pkmn-electabuzz"></span> Electabuzz - Ally ^<br />
@@ -433,7 +587,7 @@
   </div>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   </div>
   <script type="text/javascript">
     PkSpr.process_dom();
@@ -457,7 +611,7 @@
 </script>
   <a class="back-to-top btn btn-primary" href="#">Back to the top</a>
   <p class="padding">Want to count your shiny chains? <a href="https://chain-counter.github.io">Chain Couter</a> is a online service that allows you to easily count your chains, and gives you live time shiny chances, HA chances and more!</p>
-  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite</a>.</p>
+  <p class="padding"><a href="contributions.html" target="_blank">View contributions</a> to Pokesprite.</p>
   <script type="text/javascript">
     PkSpr.process_dom();
   </script>
@@ -467,7 +621,7 @@
   <script src="js/main.js" type="text/javascript"></script>
   <footer>
   <br />
-<p class="padding">By <a href="giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="github.com/giacomolaw/pokefinder" target="_blank">Pokefinder contributors</p>.
+  <p class="padding">By <a href="giacomolaw.me" target="_blank">Giacomo Lawrance</a> and other <a href="github.com/giacomolaw/pokefinder" target="_blank">Pokefinder contributors</a></p>.
   </footer>
 </body>
 </html>

--- a/night.html
+++ b/night.html
@@ -24,57 +24,83 @@
 </head>
 <body>
   <div class="main">
-    <ul>
-      <li><a href="#route1">Route 1</a></li>
-      <li><a href="#melemele-sea">Melemele Sea</a></li>
-      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
-      <li><a href="#huaoli-city">Hau'oli City</a></li>
-      <li><a href="#route2">Route 2</a></li>
-      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
-      <li><a href="#route3">Route 3</a></li>
-      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
-      <li><a href="#seward-cave">Seaward Cave</a></li>
-      <li><a href="#kalae-bay">Kala'e Bay</a></li>
-      <li><a href="#route4">Route 4</a></li>
-      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
-      <li><a href="#route5">Route 5</a></li>
-      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
-      <li><a href="#lush-jungle">Lush Jungle</a></li>
-      <li><a href="#route6">Route 6</a></li>
-      <li><a href="#route7">Route 7</a></li>
-      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
-      <li><a href="#route8">Route 8</a></li>
-      <li><a href="#route9">Route 9</a></li>
-      <li><a href="#memorial-hill">Memorial Hill</a></li>
-      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
-      <li><a href="#hano-beach">Hano Beach</a></li>
-      <li><a href="#malie-city">Malie City</a></li>
-      <li><a href="#malie-garden">Malie Garden</a></li>
-      <li><a href="#route10">Route 10</a></li>
-      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
-      <li><a href="#route11">Route 11</a></li>
-      <li><a href="#route12">Route 12</a></li>
-      <li><a href="#blush-mountain">Blush Mountain</a></li>
-      <li><a href="#route13">Route 13</a></li>
-      <li><a href="#haina-desert">Haina Desert</a></li>
-      <li><a href="#tapu-village">Tapu Village</a></li>
-      <li><a href="#route14">Route 14</a></li>
-      <li><a href="#abandoned-site">Abandoned Site</a></li>
-      <li><a href="#route15">Route 15</a></li>
-      <li><a href="#route16">Route 16</a></li>
-      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
-      <li><a href="#route17">Route 17</a></li>
-      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
-      <li><a href="#seafolk-village">Seafolk Village</a></li>
-      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
-      <li><a href="#poni-wilds">Poni Wilds</a></li>
-      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
-      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
-      <li><a href="#poni-grove">Poni Grove</a></li>
-      <li><a href="#poni-plains">Poni Plains</a></li>
-      <li><a href="#poni-meadow">Poni Meadow</a></li>
-      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
-    </ul>
+      <nav>
+          <ul>
+              <li id="melemele-island">
+                  <a href="#melemele-island">Melemele Island</a>
+                  <ul>
+                      <li><a href="#route1">Route 1</a></li>
+                      <li><a href="#melemele-sea">Melemele Sea</a></li>
+                      <li><a href="#ten-carat-hill">Ten Carat Hill</a></li>
+                      <li><a href="#huaoli-city">Hau'oli City</a></li>
+                      <li><a href="#route2">Route 2</a></li>
+                      <li><a href="#hauoli-cemetery">Hau'oli Cemetery</a></li>
+                      <li><a href="#route3">Route 3</a></li>
+                      <li><a href="#melemele-meadow">Melemele Meadow</a></li>
+                      <li><a href="#seward-cave">Seaward Cave</a></li>
+                      <li><a href="#kalae-bay">Kala'e Bay</a></li>
+                  </ul>
+              </li>
+
+              <li id="akala-island">
+                  <a href="#akala-island">Akala Island</a>
+                  <ul>
+                      <li><a href="#route4">Route 4</a></li>
+                      <li><a href="#paniola-ranch">Paniola Ranch</a></li>
+                      <li><a href="#route5">Route 5</a></li>
+                      <li><a href="#brooklet-hill">Brooklet Hill</a></li>
+                      <li><a href="#lush-jungle">Lush Jungle</a></li>
+                      <li><a href="#route6">Route 6</a></li>
+                      <li><a href="#route7">Route 7</a></li>
+                      <li><a href="#wela-volcano-park">Wela Volcano Park</a></li>
+                      <li><a href="#route8">Route 8</a></li>
+                      <li><a href="#route9">Route 9</a></li>
+                      <li><a href="#memorial-hill">Memorial Hill</a></li>
+                      <li><a href="#akala-outskirts">Akala Outskirts</a></li>
+                      <li><a href="#hano-beach">Hano Beach</a></li>
+                  </ul>
+              </li>
+
+              <li id="ula-ula-island">
+                  <a href="#ula-ula-island">Ula'ula Island</span>
+                  <ul>
+                      <li><a href="#malie-city">Malie City</a></li>
+                      <li><a href="#malie-garden">Malie Garden</a></li>
+                      <li><a href="#route10">Route 10</a></li>
+                      <li><a href="#mount-hokulani">Mount Hokulani</a></li>
+                      <li><a href="#route11">Route 11</a></li>
+                      <li><a href="#route12">Route 12</a></li>
+                      <li><a href="#blush-mountain">Blush Mountain</a></li>
+                      <li><a href="#route13">Route 13</a></li>
+                      <li><a href="#haina-desert">Haina Desert</a></li>
+                      <li><a href="#tapu-village">Tapu Village</a></li>
+                      <li><a href="#route14">Route 14</a></li>
+                      <li><a href="#abandoned-site">Abandoned Site</a></li>
+                      <li><a href="#route15">Route 15</a></li>
+                      <li><a href="#route16">Route 16</a></li>
+                      <li><a href="#ulaula-meadow">Ula'ula Meadow</a></li>
+                      <li><a href="#route17">Route 17</a></li>
+                      <li><a href="#mount-lanakila">Mount Lanakila</a></li>
+                  </ul>
+              </li>
+
+              <li id="poni-island">
+                  <a href="#poni-island">Poni Island</a>
+                  <ul>
+                      <li><a href="#seafolk-village">Seafolk Village</a></li>
+                      <li><a href="#exeggutor-island">Exeggutor Island</a></li>
+                      <li><a href="#poni-wilds">Poni Wilds</a></li>
+                      <li><a href="#vast-poni-canyon">Vast Poni Canyon</a></li>
+                      <li><a href="#poni-breaker">Poni Breaker Coast</a></li>
+                      <li><a href="#poni-grove">Poni Grove</a></li>
+                      <li><a href="#poni-plains">Poni Plains</a></li>
+                      <li><a href="#poni-meadow">Poni Meadow</a></li>
+                      <li><a href="#poni-gauntlet">Poni Gauntlet</a></li>
+                  </ul>
+              </li>
+
+          </ul>
+      </nav>
   <div class="center padding">
     <br>
     <br /><br />


### PR DESCRIPTION
This pull request adds information about name locations where it is possible to capture Pokemons.

Previously, the checklist had all the information about the numbered routes, but to complete the whole Alola pokedex, we need to check some other locations beyond the numbered routes.

So I've used Bulbapedia to visit the missing "named locations" on each island, and add the information about the Pokemons. With this, the checklist should be have all habitats and even more helpful for those that want to complete the regional dex.

[Final result Demo here](https://blog.bltavares.com/pokefinder/)

Closes issue #13 